### PR TITLE
Support to have to default when specifing an override file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ To achieve this setup the module user needs to configure Hiera in _/etc/puppet/h
 
 :puppet:
 	:datasource: data
+	:nodefault: __nodefault__
 </pre>
 
 Converting from extlookup?

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -27,6 +27,7 @@ module Puppet::Parser::Functions
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"
+        default = nil if default == config[:puppet][:nodefault] unless config[:puppet][:nodefault].nil?
 
         hiera = Hiera.new(:config => config)
 


### PR DESCRIPTION
This is a fix for https://github.com/ripienaar/hiera-puppet/issues/1

Adding support to have no default when specifing an override file.  This adds an optional config parameter to hiera.haml.

To enable this feature specify in hiera.yaml:

<pre>
:puppet:
    :nodefault: <some_string>
</pre>


Then when you use hiera in puppet:

<pre>hiera('someval', <this is the string in hiera.yaml>, overrive.file)</pre>


If someval is not found then you will get "Could not find data item someval in any Hiera data file and no default supplied."
