### PR TITLE
false vs. nil - supporting false as default value

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -13,9 +13,9 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
-        key = args[0] || nil
-        default = args[1] || nil
-        override = args[2] || nil
+        key = args[0]
+        default = args[1]
+        override = args[2]
 
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 
@@ -38,7 +38,7 @@ module Puppet::Parser::Functions
 
         answer = hiera.lookup(key, default, hiera_scope, override, :priority)
 
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") unless answer
+        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
         return answer
     end

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -4,9 +4,9 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
-        key = args[0] || nil
-        default = args[1] || nil
-        override = args[2] || nil
+        key = args[0]
+        default = args[1]
+        override = args[2]
 
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -4,9 +4,9 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
-        key = args[0] || nil
-        default = args[1] || nil
-        override = args[2] || nil
+        key = args[0]
+        default = args[1]
+        override = args[2]
 
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -4,9 +4,9 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
-        key = args[0] || nil
-        default = args[1] || nil
-        override = args[2] || nil
+        key = args[0]
+        default = args[1]
+        override = args[2]
 
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 


### PR DESCRIPTION
1st) There is no need to initialize an unset index aka.
     a = []; b=a[9999]||nil <- a[9999] will always be nil. But this
     prevents the default value to be also `false`.

2nd) unless answer will also fail if default or the answer is
     `false`, so we can't use `unless answer` here.

There are still some parts of hiera that need to be addressed to get hiera returning `false`, but I will send patches for that as well.
