### PR TITLE
Rubygems is not required to use hiera

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -20,7 +20,6 @@ module Puppet::Parser::Functions
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-        raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
         require 'hiera'
         require 'hiera/scope'

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -11,7 +11,6 @@ module Puppet::Parser::Functions
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-        raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
         require 'hiera'
         require 'hiera/scope'

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -13,7 +13,6 @@ module Puppet::Parser::Functions
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-        raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
         require 'hiera'
         require 'hiera/scope'

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -11,7 +11,6 @@ module Puppet::Parser::Functions
         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-        raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
         require 'hiera'
         require 'hiera/scope'


### PR DESCRIPTION
Hiera may be used if the hiera libs are sync'd from a puppet module via
pluginsync, even without rubygems
