### PR TITLE
Fix rake deprecation warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 
 spec = Gem::Specification.new do |s|
@@ -19,7 +19,7 @@ spec = Gem::Specification.new do |s|
   s.executables = "extlookup2hiera"
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true
 end
 


### PR DESCRIPTION
Like puppetlabs/hiera#24, the rake had this warning:
`rake/gempackagetask is deprecated. Use rubygems/package_task instead`

This commit fixes this behaviour.
