### PR TITLE
Refactor/rakefile deprecation warnings/ci tagged builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require 'rspec/core/rake_task'
 
 spec = Gem::Specification.new do |s|
@@ -19,7 +19,7 @@ spec = Gem::Specification.new do |s|
   s.executables = "extlookup2hiera"
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,16 @@
 require 'rubygems'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
+require 'tasks/release.rb'
+
+class GemVersion
+  VERSION = "0.2.0"
+end
 
 spec = Gem::Specification.new do |s|
   s.name = "hiera-puppet"
-  s.version = "0.2.0"
+  # Tag the version you want to release via an annotated tag
+  s.version = described_version
   s.author = "R.I.Pienaar"
   s.email = "rip@devco.net"
   s.homepage = "https://github.com/ripienaar/hiera-puppet"

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,0 +1,33 @@
+VERSION_FILE = 'Rakefile'
+
+def get_current_version
+  File.open( VERSION_FILE ) {|io| io.grep(/VERSION = /)}[0].split()[-1]
+end
+
+def described_version
+    # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
+    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
+end
+
+namespace :pkg do
+
+  desc "Bump version prior to release (internal task)"
+  task :versionbump  do
+    old_version =  get_current_version
+    contents = IO.read(VERSION_FILE)
+    new_version = '"' + described_version.to_s.strip + '"'
+    contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
+    file = File.open(VERSION_FILE, 'w')
+    file.write contents
+    file.close
+  end
+
+  desc "Build Package"
+  task :release => [ :versionbump, :default ] do
+    Rake::Task[:package].invoke
+  end
+
+end # namespace
+
+task :clean => [ :clobber_package ] do
+end


### PR DESCRIPTION
This commit basically mirrors stahnma's changes to puppetlabs/hiera.

This was branched off of a branch that already included puppetlabs/hiera-puppet#12 and so #12 should be merged before this branch.
