### PR TITLE
(#11728) hierayaml puppet config setting

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -17,7 +17,7 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = (File.join(Puppet.settings[:hierayaml]) or File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]))
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = (File.join(Puppet.settings[:hierayaml]) or File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]))
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = (File.join(Puppet.settings[:hierayaml]) or File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]))
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = (File.join(Puppet.settings[:hierayaml]) or File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]))
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?


### PR DESCRIPTION
Before this patch, `hiera.yaml` had a hardcoded path. Now it will be
configurable.
