### PR TITLE
Pass scope to the Hiera constructor

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -25,16 +25,13 @@ module Puppet::Parser::Functions
         require 'hiera'
         require 'hiera/scope'
 
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
         if self.respond_to?("[]")
             hiera_scope = self
         else
             hiera_scope = Hiera::Scope.new(self)
         end
+
+        hiera = Hiera.new({:logger => 'puppet', :config => configfile}, hiera_scope)
 
         answer = hiera.lookup(key, default, hiera_scope, override, :priority)
 

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -16,16 +16,13 @@ module Puppet::Parser::Functions
         require 'hiera'
         require 'hiera/scope'
 
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
         if self.respond_to?("[]")
             hiera_scope = self
         else
             hiera_scope = Hiera::Scope.new(self)
         end
+
+        hiera = Hiera.new({:logger => 'puppet', :config => configfile}, hiera_scope)
 
         answer = hiera.lookup(key, default, hiera_scope, override, :array)
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -16,16 +16,13 @@ module Puppet::Parser::Functions
         require 'hiera'
         require 'hiera/scope'
 
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
         if self.respond_to?("{}")
             hiera_scope = self
         else
             hiera_scope = Hiera::Scope.new(self)
         end
+
+        hiera = Hiera.new({:logger => 'puppet', :config => configfile}, hiera_scope)
 
         answer = hiera.lookup(key, default, hiera_scope, override, :hash)
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -16,16 +16,13 @@ module Puppet::Parser::Functions
         require 'hiera'
         require 'hiera/scope'
 
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
         if self.respond_to?("[]")
             hiera_scope = self
         else
             hiera_scope = Hiera::Scope.new(self)
         end
+
+        hiera = Hiera.new({:logger => 'puppet', :config => configfile}, hiera_scope)
 
         answer = hiera.lookup(key, default, hiera_scope, override, :array)
 


### PR DESCRIPTION
Before this commit, if the Hiera constructor accepted scope as per the
puppetlabs/hiera project, branch feature/parse_hiera_yaml, then it was
impossible to actually pass scope.

This commit allows scope to be passed to the Hiera constructor.

All tests pass.
