### PR TITLE
Ready repository for release process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,28 @@
 require 'rubygems'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require 'rspec/core/rake_task'
+require 'tasks/release'
+
 
 spec = Gem::Specification.new do |s|
   s.name = "hiera-puppet"
-  s.version = "0.2.0"
-  s.author = "R.I.Pienaar"
-  s.email = "rip@devco.net"
-  s.homepage = "https://github.com/ripienaar/hiera-puppet"
+  s.version = described_version
+  s.author = "Puppet Labs"
+  s.email = "info@puppetlabs.com"
+  s.homepage = "https://github.com/puppetlabs/hiera-puppet"
   s.platform = Gem::Platform::RUBY
   s.summary = "Puppet query interface and backend for Hiera"
   s.description = "Store and query Hiera data from Puppet"
   s.files = FileList["{bin,lib}/**/*"].to_a
   s.require_path = "lib"
-  s.test_files = FileList["spec/**/*test.rb"].to_a
+  s.test_files = FileList["spec/**/*.rb"].to_a
   s.has_rdoc = true
-  s.add_dependency 'hiera', '~>0.2.0'
+  s.add_dependency 'hiera', '~>0.3.0'
   s.executables = "extlookup2hiera"
 end
 
-Rake::GemPackageTask.new(spec) do |pkg|
+
+Gem::PackageTask.new(spec) do  |pkg|
   pkg.need_tar = true
 end
 

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,0 +1,23 @@
+
+VERSION_FILE = 'lib/hiera.rb'
+
+def get_current_version
+  File.open( VERSION_FILE ) {|io| io.grep(/VERSION = /)}[0].split()[-1]
+end
+
+def described_version
+    # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
+    %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
+end
+
+namespace :pkg do
+
+  desc "Build Package"
+  task :release => [ :default ] do
+    Rake::Task[:package].invoke
+  end
+
+end # namespace
+
+task :clean => [ :clobber_package ] do
+end


### PR DESCRIPTION
This commit modifies the behavior of the Rake task to use the tagged
version as the version of the repository/gem.  This will allow for
autobuilding in the future.  This is extremely similar to the heira
Rakefile and tasks.

Also got rid of a package_task warning in the Rakefile.

I also tagged the original commit at v0.0.0 to ensure this process would
work.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
