### PR TITLE
Raise a ParseError if a lookup key isn't passed

### DIFF
--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -4,6 +4,8 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
+        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
+
         key = args[0]
         default = args[1]
         override = args[2]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,10 +11,3 @@ RSpec.configure do |config|
     config.mock_with :mocha
 end
 
-class Puppet
-    class Parser
-        class Functions
-        end
-    end
-end
-

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -1,0 +1,11 @@
+require 'puppet'
+require 'hiera'
+require 'spec_helper'
+
+describe 'Puppet::Parser::Functions#hiera_hash' do
+  it 'should require a key argument' do
+    Puppet::Parser::Functions.function(:hiera_hash)
+    @scope = Puppet::Parser::Scope.new
+    expect { @scope.function_hiera_hash([]) }.should raise_error(Puppet::ParseError)
+  end
+end

--- a/spec/unit/puppet_backend_spec.rb
+++ b/spec/unit/puppet_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class Hiera
     module Backend

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class Hiera
     describe Scope do


### PR DESCRIPTION
Hiera should raise a parse error if a lookup key isn't passed.  Also, test coverage was added to catch any future regressions.
