### PR TITLE
(#12037) hiera-puppet should support hash values.

### DIFF
--- a/lib/hiera/backend/puppet_backend.rb
+++ b/lib/hiera/backend/puppet_backend.rb
@@ -74,6 +74,8 @@ class Hiera
                         case resolution_type
                         when :array
                             answer << Backend.parse_answer(temp_answer, scope)
+                        when :hash
+                            answer = Backend.parse_answer(temp_answer, scope).merge answer
                         else
                             answer = Backend.parse_answer(temp_answer, scope)
                             break

--- a/spec/unit/puppet_backend_spec.rb
+++ b/spec/unit/puppet_backend_spec.rb
@@ -110,6 +110,37 @@ class Hiera
                         @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
                         @backend.lookup("key", @scope, nil, :array).should == ["rspec::key", "test::key"]
                     end
+
+
+                    it "should return a hash of found data for hash searches" do
+                        Backend.expects(:empty_answer).returns({})
+                        Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key'})
+                        Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key'})
+                        catalog = mock
+                        catalog.expects(:classes).returns(["rspec", "test"])
+                        @mockscope.expects(:catalog).returns(catalog)
+                        @mockscope.expects(:function_include).never
+                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
+                        @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
+
+                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
+                        @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'test'=>'key'}
+                    end
+
+                    it "should return a merged hash of found data for hash searches" do
+                        Backend.expects(:empty_answer).returns({})
+                        Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key', 'common'=>'rspec'})
+                        Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key', 'common'=>'rspec'})
+                        catalog = mock
+                        catalog.expects(:classes).returns(["rspec", "test"])
+                        @mockscope.expects(:catalog).returns(catalog)
+                        @mockscope.expects(:function_include).never
+                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
+                        @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
+
+                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
+                        @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'common'=>'rspec', 'test'=>'key'}
+                    end
                 end
             end
         end


### PR DESCRIPTION
Puppet support hashes, so hiera-puppet backend should also support hash
values.
