### PR TITLE
Make hiera work in puppet standalone

### DIFF
--- a/lib/hiera-gem/CHANGES.txt
+++ b/lib/hiera-gem/CHANGES.txt
@@ -1,0 +1,11 @@
+2011/06/26 - Add support for hashes from backend
+2011/06/21 - Fix an issue handling defaults in array searches
+2011/06/12 - Release 0.2.0
+2011/06/11 - Add a Puppet logger plugin
+2011/06/11 - Parse variables in String, Hash and Array data
+2011/06/11 - Add a array merge search option to the framework and yaml
+             data source
+2011/06/08 - Support reading facts from a mcollective server as scope
+             on the CLI
+2011/06/05 - Change /bin/env to /usr/bin/env for better portability
+2011/06/05 - Correct URL for homepage and paths to tests in the Gem

--- a/lib/hiera-gem/COPYING
+++ b/lib/hiera-gem/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2010, 2011 R.I.Pienaar, Puppet Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/hiera-gem/README.md
+++ b/lib/hiera-gem/README.md
@@ -1,0 +1,234 @@
+What?
+=====
+
+A simple pluggable Hierarchical Database.
+
+Why?
+====
+
+Hierarchical data is a good fit for the representation of infrastructure information.
+Consider the example of a typical company with 2 datacenters and on-site development,
+staging etc.
+
+All machines need:
+
+ - ntp servers
+ - sysadmin contacts
+
+By thinking about the data in a hierarchical manner you can resolve these to the most
+correct answer easily:
+
+<pre>
+     /------------- DC1 -------------\             /------------- DC2 -------------\
+    | ntpserver: ntp1.dc1.example.com |           | ntpserver: ntp1.dc2.example.com |
+    | sysadmin: dc1noc@example.com    |           |                                 |
+    | classes: users::dc1             |           | classes: users::dc2             |
+     \-------------------------------/             \-------------------------------/
+                                \                      /
+                                  \                  /
+                           /------------- COMMON -------------\
+                          | ntpserver: 1.pool.ntp.org          |
+                          | sysadmin: sysadmin@%{domain}       |
+                          | classes: users::common             |
+                           \----------------------------------/
+</pre>
+
+In this simple example machines in DC1 and DC2 have their own NTP servers, additionaly
+DC1 has its own sysadmin contact - perhaps because its a remote DR site - while DC2
+and all the other environments would revert to the common contact that would have the
+machines domain fact expanded into the result.
+
+The _classes_ variable can be searched using the array method which would build up a
+list of classes to include on a node based on the hierarchy.  Machines in DC1 would have
+the classes _users::common_ and _users::dc1_.
+
+The other environment like development and staging would all use the public NTP infrastructure.
+
+This is the data model that extlookup() have promoted in Puppet, Hiera has taken this
+data model and extracted it into a standalone project that is pluggable and have a few
+refinements over extlookup.
+
+Enhancements over Extlookup?
+============================
+
+Extlookup had just one backend, Hiera can be extended with your own backends and represent
+a few enhancements over the base Extlookup approach thanks to this.
+
+Multiple backends are queried
+-----------------------------
+If you have a YAML and Puppet backend loaded and your users provide module defaults in the
+Puppet backend you can use your YAML data to override the Puppet data.  If the YAML doesnt
+provide an answer the Puppet backend will get an oppertunity to provide an answer.
+
+More scope based variable expansion
+-----------------------------------
+Extlookup could parse data like %{foo} into a scope lookup for the variable foo.  Hiera
+retains this ability and any Arrays or Hashes will be recursively searched for all strings
+that will then be parsed.
+
+The datadir and defaults are now also subject to variable parsing based on scope.
+
+No CSV support by default
+-------------------------
+We have not at present provided a backward compatible CSV backend.  A converter to
+YAML or JSON should be written. When the CSV backend was first chosen for Puppet the
+Puppet language only supports strings and arrays of strings which mapped well to CSV.
+Puppet has become (a bit) better wrt data and can now handle hashes and arrays of hashes
+so it's a good time to retire the old data format.
+
+Array Searches
+--------------
+Hiera can search through all the tiers in a hierarchy and merge the result into a single
+array.  This is used in the hiera-puppet project to replace External Node Classifiers by
+creating a Hiera compatible include function.
+
+Future Enhancements?
+====================
+
+ * More backends should be created
+ * A webservice that exposes the data
+ * Tools to help maintain the data files.  Ideally this would be Foreman and Dashboard
+   with their own backends
+
+Installation?
+=============
+
+Hiera is available as a Gem called _hiera_ and out of the box it comes with just a single
+YAML backend.
+
+At present JSON (github/ripienaar/hiera-json) and Puppet (hiera-puppet) backends are availble.
+
+Configuration?
+==============
+
+You can configure Hiera using a YAML file or by providing it Hash data in your code.  There
+isn't a default config path - the CLI script will probably assume _/etc/hiera.yaml_ though.
+The default data directory for file based storage is _/var/lib/hiera_.
+
+A sample configuration file can be seen here:
+
+<pre>
+---
+:backends: - yaml
+           - puppet
+
+:logger: console
+
+:hierarchy: - %{location}
+            - common
+:yaml:
+   :datadir: /etc/puppet/hieradata
+
+:puppet:
+   :datasource: data
+</pre>
+
+This configuration will require YAML files in  _/etc/puppet/hieradata_ these need to contain
+Hash data, sample files matching the hierarchy described in the _Why?_ section are below:
+
+_/etc/puppet/hieradata/dc1.yaml_:
+<pre>
+---
+ntpserver: ntp1.dc1.example.com
+sysadmin: dc1noc@example.com
+</pre>
+
+_/etc/puppet/hieradata/dc2.yaml_:
+<pre>
+---
+ntpserver: ntp1.dc2.example.com
+</pre>
+
+_/etc/puppet/hieradata/common.yaml_:
+<pre>
+---
+sysadmin: sysadmin@%{domain}
+ntpserver: 1.pool.ntp.org
+</pre>
+
+Querying from CLI?
+==================
+
+You can query your data from the CLI.  By default the CLI expects a config file in _/etc/hiera.yaml_
+but you can pass _--config_ to override that.
+
+This example searches Hiera for node data.  Scope is loaded from a Puppet created YAML facts
+store as found on your Puppet Masters.
+
+If no data is found and the facts had a location=dc1 fact the default would be _sites/dc1_
+
+<pre>
+$ hiera acme_version 'sites/%{location}' --yaml /var/lib/puppet/yaml/facts/example.com.yaml
+</pre>
+
+You can also supply extra facts on the CLI, assuming Puppet facts did not have a location fact:
+
+<pre>
+$ hiera acme_version 'sites/%{location}' location=dc1 --yaml /var/lib/puppet/yaml/facts/example.com.yaml
+</pre>
+
+Or if you use MCollective you can fetch the scope from a remote node's facts:
+
+<pre>
+$ hiera acme_version 'sites/%{location}' -m box.example.com
+</pre>
+
+You can also do array merge searches on the CLI:
+
+<pre>
+$ hiera -a classes location=dc1
+["users::common", "users::dc1"]
+</pre>
+
+Querying from code?
+===================
+
+This is the same query programatically as in the above CLI example:
+
+<pre>
+require 'rubygems'
+require 'hiera'
+require 'puppet'
+
+# load the facts for example.com
+scope = YAML.load_file("/var/lib/puppet/yaml/facts/example.com.yaml").values
+
+# create a new instance based on config file
+hiera = Hiera.new(:config => "/etc/puppet/hiera.yaml")
+
+# resolve the 'acme_version' variable based on scope
+#
+# given a fact location=dc1 in the facts file this will default to a branch sites/dc1
+# and allow hierarchical overrides based on the hierarchy defined in the config file
+puts "ACME Software Version: %s" % [ hiera.lookup("acme_version", "sites/%{location}", scope) ]
+</pre>
+
+Extending?
+==========
+
+There exist 2 backends at present in addition to the bundled YAML one.
+
+JSON
+----
+This can be found on github under _ripienaar/hiera-json_.  This is a good example
+of file based backends as Hiera provides a number of helpers to make writing these
+trivial.
+
+Puppet
+-------
+This is much more complex and queries the data from the running Puppet state, it's found
+on GitHub under _ripienaar/hiera-puppet_.
+
+This is a good example to learn how to map your internal program state into what Hiera
+wants as I needed to do with the Puppet Scope.
+
+It includes a Puppet Parser Function to query the data from within Puppet.
+
+When used in Puppet you'd expect Hiera to log using the Puppet infrastructure, this
+plugin includes a Puppet Logger plugin for Hiera that uses the normal Puppet logging
+methods for all logging.
+
+Contact?
+========
+
+R.I.Pienaar / rip@devco.net / @ripienaar / www.devco.net

--- a/lib/hiera-gem/Rakefile
+++ b/lib/hiera-gem/Rakefile
@@ -1,0 +1,33 @@
+require 'rubygems'
+require 'rubygems/package_task'
+require 'rspec/core/rake_task'
+require 'tasks/release.rb'
+
+spec = Gem::Specification.new do |s|
+  s.name = "hiera"
+  # Tag the version you want to release via an annotated tag
+  s.version = described_version
+  s.author = "Puppet Labs"
+  s.email = "info@puppetlabs.com"
+  s.homepage = "https://github.com/puppetlabs/hiera/"
+  s.summary = "Light weight hierarcical data store"
+  s.description = "A pluggable data store for hierarcical data"
+  s.files = FileList["{bin,lib}/**/*"].to_a
+  s.require_path = "lib"
+  s.test_files = FileList["spec/**/*"].to_a
+  s.has_rdoc = true
+  s.executables = "hiera"
+  s.default_executable = "hiera"
+end
+
+Gem::PackageTask.new(spec) do |pkg|
+  pkg.need_tar = true
+end
+
+desc "Run all specs"
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+  t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+end
+
+task :default => [:test, :repackage]

--- a/lib/hiera-gem/bin/hiera
+++ b/lib/hiera-gem/bin/hiera
@@ -1,0 +1,214 @@
+#!/usr/bin/env ruby
+
+# CLI client for Hiera.
+#
+# To lookup the 'release' key for a node given Puppet YAML facts:
+#
+# $ hiera release 'rel/%{location}' --yaml some.node.yaml
+#
+# If the node yaml had a location fact the default would match that
+# else you can supply scope values on the command line
+#
+# $ hiera release 'rel/%{location}' location=dc2 --yaml some.node.yaml
+
+require 'rubygems'
+require 'hiera'
+require 'optparse'
+
+options = {:default => nil, :config => "/etc/hiera.yaml", :scope => {}, :key => nil, :verbose => false, :resolution_type => :priority}
+
+class Hiera::Noop_logger
+  class << self
+    def warn(msg);end
+    def debug(msg);end
+  end
+end
+
+# Loads the scope from YAML or JSON files
+def load_scope(source, type=:yaml)
+  case type
+  when :mcollective
+    begin
+      require 'mcollective'
+
+      include MCollective::RPC
+
+      util = rpcclient("rpcutil")
+      util.progress = false
+      nodestats = util.custom_request("inventory", {}, source, {"identity" => source}).first
+
+      raise "Failed to retrieve facts for node #{source}: #{nodestats[:statusmsg]}" unless nodestats[:statuscode] == 0
+
+      scope = nodestats[:data][:facts]
+    rescue Exception => e
+      STDERR.puts "MCollective lookup failed: #{e.class}: #{e}"
+      exit 1
+    end
+
+  when :yaml
+    raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
+
+    require 'yaml'
+
+    # Attempt to load puppet in case we're going to be fed
+    # Puppet yaml files
+    begin
+        require 'puppet'
+    rescue
+    end
+
+    scope = YAML.load_file(source)
+
+    # Puppet makes dumb yaml files that do not promote data reuse.
+    scope = scope.values if scope.is_a?(Puppet::Node::Facts)
+
+  when :json
+    raise "Cannot find scope #{type} file #{source}" unless File.exist?(source)
+
+    require 'json'
+
+    scope = JSON.load(File.read(source))
+
+  when :inventory_service
+    # For this to work the machine running the hiera command needs access to
+    # /facts REST endpoint on your inventory server.  This access is
+    # controlled in auth.conf and identification is by the certname of the
+    # machine running hiera commands.
+    #
+    # Another caveat is that if your inventory server isn't at the short dns
+    # name of 'puppet' you will need to set the inventory_sever option in
+    # your puppet.conf.  Set it in either the master or main sections.  It
+    # is fine to have the inventory_server option set even if the config
+    # doesn't have the fact_terminus set to rest.
+    begin
+      require 'puppet/util/run_mode'
+      $puppet_application_mode = Puppet::Util::RunMode[:master]
+      require 'puppet'
+      Puppet.settings.parse
+      Puppet::Node::Facts.indirection.terminus_class = :rest
+      scope = YAML.load(Puppet::Node::Facts.indirection.find(source).to_yaml)
+      # Puppet makes dumb yaml files that do not promote data reuse.
+      scope = scope.values if scope.is_a?(Puppet::Node::Facts)
+    rescue Exception => e
+        STDERR.puts "Puppet inventory service lookup failed: #{e.class}: #{e}"
+        exit 1
+    end
+  else
+    raise "Don't know how to load data type #{type}"
+  end
+
+  raise "Scope from #{type} file #{source} should be a Hash" unless scope.is_a?(Hash)
+
+  scope
+end
+
+OptionParser.new do |opts|
+  opts.on("--version", "-V", "Version information") do
+    puts Hiera.version
+    exit
+  end
+
+  opts.on("--debug", "-d", "Show debugging information") do
+    options[:verbose] = true
+  end
+
+  opts.on("--array", "-a", "Array search") do
+    options[:resolution_type] = :array
+  end
+
+  opts.on("--hash", "-h", "Hash search") do
+    options[:resolution_type] = :hash
+  end
+
+  opts.on("--config CONFIG", "-c", "Configuration file") do |v|
+    if File.exist?(v)
+      options[:config] = v
+    else
+      STDERR.puts "Cannot find config file: #{v}"
+      exit 1
+    end
+  end
+
+  opts.on("--json SCOPE", "-j", "JSON format file to load scope from") do |v|
+    begin
+      options[:scope] = load_scope(v, :json)
+    rescue Exception => e
+      STDERR.puts "Could not load JSON scope: #{e.class}: #{e}"
+      exit 1
+    end
+  end
+
+  opts.on("--yaml SCOPE", "-y", "YAML format file to load scope from") do |v|
+    begin
+      options[:scope] = load_scope(v)
+    rescue Exception => e
+      STDERR.puts "Could not load YAML scope: #{e.class}: #{e}"
+      exit 1
+    end
+  end
+
+  opts.on("--mcollective IDENTITY", "-m", "Retrieve facts from a node via mcollective as scope") do |v|
+    begin
+      options[:scope] = load_scope(v, :mcollective)
+    rescue Exception => e
+      STDERR.puts "Could not load MCollective scope: #{e.class}: #{e}"
+      exit 1
+    end
+  end
+
+  opts.on("--inventory_service IDENTITY", "-i", "Retrieve facts for a node via Puppet's inventory service as scope") do |v|
+    begin
+      options[:scope] = load_scope(v, :inventory_service)
+    rescue Exception => e
+      STDERR.puts "Could not load Puppet inventory service scope: #{e.class}: #{e}"
+      exit 1
+    end
+  end
+end.parse!
+
+# arguments can be:
+#
+# key default var=val another=val
+#
+# The var=val's assign scope
+unless ARGV.empty?
+  options[:key] = ARGV.delete_at(0)
+
+  ARGV.each do |arg|
+    if arg =~ /^(.+?)=(.+?)$/
+      options[:scope][$1] = $2
+    else
+      unless options[:default]
+        options[:default] = arg.dup
+      else
+        STDERR.puts "Don't know how to parse scope argument: #{arg}"
+      end
+    end
+  end
+else
+  STDERR.puts "Please supply a data item to look up"
+  exit 1
+end
+
+begin
+  hiera = Hiera.new(:config => options[:config])
+rescue Exception => e
+  if options[:verbose]
+    raise
+  else
+    STDERR.puts "Failed to start Hiera: #{e.class}: #{e}"
+    exit 1
+  end
+end
+
+unless options[:verbose]
+  Hiera.logger = "noop"
+end
+
+ans = hiera.lookup(options[:key], options[:default], options[:scope], nil, options[:resolution_type])
+
+if ans.is_a?(String)
+  puts ans
+else
+  p ans
+end

--- a/lib/hiera-gem/lib/hiera.rb
+++ b/lib/hiera-gem/lib/hiera.rb
@@ -1,0 +1,61 @@
+require 'rubygems'
+require 'yaml'
+
+class Hiera
+  VERSION = "0.3.0"
+
+  autoload :Config, "hiera/config"
+  autoload :Backend, "hiera/backend"
+  autoload :Console_logger, "hiera/console_logger"
+  autoload :Puppet_logger, "hiera/puppet_logger"
+
+  class << self
+    def version
+      VERSION
+    end
+
+    # Loggers are pluggable, just provide a class called
+    # Hiera::Foo_logger and respond to :warn and :debug
+    #
+    # See hiera-puppet for an example that uses the Puppet
+    # loging system instead of our own
+    def logger=(logger)
+      loggerclass = "#{logger.capitalize}_logger"
+
+      require "hiera/#{logger}_logger" unless constants.include?(loggerclass)
+
+      @logger = const_get(loggerclass)
+    rescue Exception => e
+      @logger = Console_logger
+      warn("Failed to load #{logger} logger: #{e.class}: #{e}")
+    end
+
+    def warn(msg); @logger.warn(msg); end
+    def debug(msg); @logger.debug(msg); end
+  end
+
+  attr_reader :options, :config
+
+  # If the config option is a string its assumed to be a filename,
+  # else a hash of what would have been in the YAML config file
+  def initialize(options={})
+    options[:config] ||= "/etc/hiera.yaml"
+
+    @config = Config.load(options[:config])
+
+    Config.load_backends
+  end
+
+  # Calls the backends to do the actual lookup.
+  #
+  # The scope can be anything that responds to [], if you have input
+  # data like a Puppet Scope that does not you can wrap that data in a
+  # class that has a [] method that fetches the data from your source.
+  # See hiera-puppet for an example of this.
+  #
+  # The order-override will insert as first in the hierarchy a data source
+  # of your choice.
+  def lookup(key, default, scope, order_override=nil, resolution_type=:priority)
+    Backend.lookup(key, default, scope, order_override, resolution_type)
+  end
+end

--- a/lib/hiera-gem/lib/hiera/backend.rb
+++ b/lib/hiera-gem/lib/hiera/backend.rb
@@ -1,0 +1,174 @@
+class Hiera
+  module Backend
+    class << self
+      # Data lives in /var/lib/hiera by default.  If a backend
+      # supplies a datadir in the config it will be used and
+      # subject to variable expansion based on scope
+      def datadir(backend, scope)
+        backend = backend.to_sym
+        default = "/var/lib/hiera"
+
+        if Config.include?(backend)
+          parse_string(Config[backend][:datadir] || default, scope)
+        else
+          parse_string(default, scope)
+        end
+      end
+
+      # Finds the path to a datafile based on the Backend#datadir
+      # and extension
+      #
+      # If the file is not found nil is returned
+      def datafile(backend, scope, source, extension)
+        file = File.join([datadir(backend, scope), "#{source}.#{extension}"])
+
+        unless File.exist?(file)
+          Hiera.debug("Cannot find datafile #{file}, skipping")
+
+          return nil
+        end
+
+        return file
+      end
+
+      # Returns an appropriate empty answer dependant on resolution type
+      def empty_answer(resolution_type)
+        case resolution_type
+        when :array
+          return []
+        when :hash
+          return {}
+        else
+          return nil
+        end
+      end
+
+      # Constructs a list of data sources to search
+      #
+      # If you give it a specific hierarchy it will just use that
+      # else it will use the global configured one, failing that
+      # it will just look in the 'common' data source.
+      #
+      # An override can be supplied that will be pre-pended to the
+      # hierarchy.
+      #
+      # The source names will be subject to variable expansion based
+      # on scope
+      def datasources(scope, override=nil, hierarchy=nil)
+        if hierarchy
+          hierarchy = [hierarchy]
+        elsif Config.include?(:hierarchy)
+          hierarchy = [Config[:hierarchy]].flatten
+        else
+          hierarchy = ["common"]
+        end
+
+        hierarchy.insert(0, override) if override
+
+        hierarchy.flatten.map do |source|
+          source = parse_string(source, scope)
+          yield(source) unless source == "" or source =~ /(^\/|\/\/|\/$)/
+        end
+      end
+
+      # Parse a string like '%{foo}' against a supplied
+      # scope and additional scope.  If either scope or
+      # extra_scope includes the varaible 'foo' it will
+      # be replaced else an empty string will be placed.
+      #
+      # If both scope and extra_data has "foo" scope
+      # will win.  See hiera-puppet for an example of
+      # this to make hiera aware of additional non scope
+      # variables
+      def parse_string(data, scope, extra_data={})
+        return nil unless data
+
+        tdata = data.clone
+
+        if tdata.is_a?(String)
+          while tdata =~ /%\{(.+?)\}/
+            var = $1
+            val = scope[var] || extra_data[var] || ""
+
+            # Puppet can return this for unknown scope vars
+            val = "" if val == :undefined
+
+            tdata.gsub!(/%\{#{var}\}/, val)
+          end
+        end
+
+        return tdata
+      end
+
+      # Parses a answer received from data files
+      #
+      # Ultimately it just pass the data through parse_string but
+      # it makes some effort to handle arrays of strings as well
+      def parse_answer(data, scope, extra_data={})
+        if data.is_a?(Numeric) or data.is_a?(TrueClass) or data.is_a?(FalseClass)
+          return data
+        elsif data.is_a?(String)
+          return parse_string(data, scope, extra_data)
+        elsif data.is_a?(Hash)
+          answer = {}
+          data.each_pair do |key, val|
+            answer[key] = parse_answer(val, scope, extra_data)
+          end
+
+          return answer
+        elsif data.is_a?(Array)
+          answer = []
+          data.each do |item|
+            answer << parse_answer(item, scope, extra_data)
+          end
+
+          return answer
+        end
+      end
+
+      def resolve_answer(answer, resolution_type)
+        case resolution_type
+        when :array
+          [answer].flatten.uniq.compact
+        when :hash
+          answer # Hash structure should be preserved
+        else
+          answer
+        end
+      end
+
+      # Calls out to all configured backends in the order they
+      # were specified.  The first one to answer will win.
+      #
+      # This lets you declare multiple backends, a possible
+      # use case might be in Puppet where a Puppet module declares
+      # default data using in-module data while users can override
+      # using JSON/YAML etc.  By layering the backends and putting
+      # the Puppet one last you can override module author data
+      # easily.
+      #
+      # Backend instances are cached so if you need to connect to any
+      # databases then do so in your constructor, future calls to your
+      # backend will not create new instances
+      def lookup(key, default, scope, order_override, resolution_type)
+        @backends ||= {}
+        answer = nil
+
+        Config[:backends].each do |backend|
+          if constants.include?("#{backend.capitalize}_backend") || constants.include?("#{backend.capitalize}_backend".to_sym)
+            @backends[backend] ||= Backend.const_get("#{backend.capitalize}_backend").new
+            answer = @backends[backend].lookup(key, scope, order_override, resolution_type)
+
+            break if answer
+          end
+        end
+
+        answer = resolve_answer(answer, resolution_type)
+        answer = parse_string(default, scope) if answer.nil?
+
+        return default if answer == empty_answer(resolution_type)
+        return answer
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/lib/hiera/backend/yaml_backend.rb
+++ b/lib/hiera-gem/lib/hiera/backend/yaml_backend.rb
@@ -1,0 +1,49 @@
+class Hiera
+  module Backend
+    class Yaml_backend
+      def initialize
+        require 'yaml'
+
+        Hiera.debug("Hiera YAML backend starting")
+      end
+
+      def lookup(key, scope, order_override, resolution_type)
+        answer = Backend.empty_answer(resolution_type)
+
+        Hiera.debug("Looking up #{key} in YAML backend")
+
+        Backend.datasources(scope, order_override) do |source|
+          Hiera.debug("Looking for data source #{source}")
+
+          yamlfile = Backend.datafile(:yaml, scope, source, "yaml") || next
+
+          data = YAML.load_file(yamlfile)
+
+          next if ! data
+          next if data.empty?
+          next unless data.include?(key)
+
+          # for array resolution we just append to the array whatever
+          # we find, we then goes onto the next file and keep adding to
+          # the array
+          #
+          # for priority searches we break after the first found data item
+          new_answer = Backend.parse_answer(data[key], scope)
+          case resolution_type
+          when :array
+            raise Exception, "Hiera type mismatch: expected Array and got #{new_answer.class}" unless new_answer.kind_of? Array or new_answer.kind_of? String
+            answer << new_answer
+          when :hash
+            raise Exception, "Hiera type mismatch: expected Hash and got #{new_answer.class}" unless new_answer.kind_of? Hash
+            answer = new_answer.merge answer
+          else
+            answer = new_answer
+            break
+          end
+        end
+
+        return answer
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/lib/hiera/config.rb
+++ b/lib/hiera-gem/lib/hiera/config.rb
@@ -1,0 +1,51 @@
+class Hiera::Config
+  class << self
+    # Takes a string or hash as input, strings are treated as filenames
+    # hashes are stored as data that would have been in the config file
+    #
+    # Unless specified it will only use YAML as backend with a single
+    # 'common' hierarchy and console logger
+    def load(source)
+      @config = {:backends => "yaml",
+                 :hierarchy => "common"}
+
+      if source.is_a?(String)
+        raise "Config file #{source} not found" unless File.exist?(source)
+
+        config = YAML.load_file(source)
+        @config.merge! config if config
+      elsif source.is_a?(Hash)
+        @config.merge! source
+      end
+
+      @config[:backends] = [ @config[:backends] ].flatten
+
+      if @config.include?(:logger)
+        Hiera.logger = @config[:logger].to_s
+      else
+        @config[:logger] = "console"
+        Hiera.logger = "console"
+      end
+
+      @config
+    end
+
+    def load_backends
+      @config[:backends].each do |backend|
+        begin
+          require "hiera/backend/#{backend.downcase}_backend"
+        rescue LoadError => e
+          Hiera.warn "Cannot load backend #{backend}: #{e}"
+        end
+      end
+    end
+
+    def include?(key)
+      @config.include?(key)
+    end
+
+    def [](key)
+      @config[key]
+    end
+  end
+end

--- a/lib/hiera-gem/lib/hiera/console_logger.rb
+++ b/lib/hiera-gem/lib/hiera/console_logger.rb
@@ -1,0 +1,13 @@
+class Hiera
+  module Console_logger
+    class << self
+      def warn(msg)
+        STDERR.puts("WARN: %s: %s" % [Time.now.to_s, msg])
+      end
+
+      def debug(msg)
+        STDERR.puts("DEBUG: %s: %s" % [Time.now.to_s, msg])
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/lib/hiera/puppet_logger.rb
+++ b/lib/hiera-gem/lib/hiera/puppet_logger.rb
@@ -1,0 +1,8 @@
+class Hiera
+  module Puppet_logger
+    class << self
+      def warn(msg); Puppet.notice("hiera(): #{msg}"); end
+      def debug(msg); Puppet.debug("hiera(): #{msg}"); end
+    end
+  end
+end

--- a/lib/hiera-gem/spec/spec.opts
+++ b/lib/hiera-gem/spec/spec.opts
@@ -1,0 +1,1 @@
+--format s --colour --backtrace

--- a/lib/hiera-gem/spec/spec_helper.rb
+++ b/lib/hiera-gem/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+$:.insert(0, File.join([File.dirname(__FILE__), "..", "lib"]))
+
+require 'rubygems'
+require 'rspec'
+require 'hiera'
+require 'rspec/mocks'
+require 'mocha'
+
+RSpec.configure do |config|
+  config.mock_with :mocha
+end
+
+class Puppet
+  class Parser
+    class Functions
+    end
+  end
+end
+

--- a/lib/hiera-gem/spec/unit/backend/yaml_backend_spec.rb
+++ b/lib/hiera-gem/spec/unit/backend/yaml_backend_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+require 'hiera/backend/yaml_backend'
+
+class Hiera
+  module Backend
+    describe Yaml_backend do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+        @backend = Yaml_backend.new
+      end
+
+      describe "#initialize" do
+        it "should announce its creation" do # because other specs checks this
+          Hiera.expects(:debug).with("Hiera YAML backend starting")
+          Yaml_backend.new
+        end
+      end
+
+      describe "#lookup" do
+        it "should look for data in all sources" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil)
+
+          @backend.lookup("key", {}, nil, :priority)
+        end
+
+        it "should pick data earliest source that has it for priority searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns(nil).never
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
+
+          @backend.lookup("key", {}, nil, :priority).should == "answer"
+        end
+
+        it "should not look up missing data files" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns(nil)
+          YAML.expects(:load_file).never
+
+          @backend.lookup("key", {}, nil, :priority)
+        end
+
+        it "should return nil for empty data files" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+
+          @backend.lookup("key", {}, nil, :priority).should be_nil
+        end
+
+        it "should build an array of all data sources for array searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey: answer"))
+
+          @backend.lookup("key", {}, nil, :array).should == ["answer", "answer"]
+        end
+
+        it "should return empty hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+
+          @backend.lookup("key", {}, nil, :hash).should == {}
+        end
+
+        it "should ignore empty hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load(""))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+
+          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer"}
+        end
+
+        it "should build a merged hash of data sources for hash searches" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: wrong\n b: answer"))
+
+          @backend.lookup("key", {}, nil, :hash).should == {"a" => "answer", "b" => "answer"}
+        end
+
+        it "should fail when trying to << a Hash" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n- a\n- answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+
+          lambda {@backend.lookup("key", {}, nil, :array)}.should raise_error(Exception, "Hiera type mismatch: expected Array and got Hash")
+        end
+
+        it "should fail when trying to merge an Array" do
+          Backend.expects(:datasources).multiple_yields(["one"], ["two"])
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml")
+          Backend.expects(:datafile).with(:yaml, {}, "two", "yaml").returns("/nonexisting/two.yaml")
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey:\n a: answer"))
+          YAML.expects(:load_file).with("/nonexisting/two.yaml").returns(YAML.load("---\nkey:\n- a\n- wrong"))
+
+          lambda {@backend.lookup("key", {}, nil, :hash)}.should raise_error(Exception, "Hiera type mismatch: expected Hash and got Array")
+        end
+
+        it "should parse the answer for scope variables" do
+          Backend.expects(:datasources).yields("one")
+          Backend.expects(:datafile).with(:yaml, {"rspec" => "test"}, "one", "yaml").returns("/nonexisting/one.yaml")
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nkey: 'test_%{rspec}'"))
+
+          @backend.lookup("key", {"rspec" => "test"}, nil, :priority).should == "test_test"
+        end
+
+        it "should retain datatypes found in yaml files" do
+          Backend.expects(:datasources).yields("one").times(3)
+          Backend.expects(:datafile).with(:yaml, {}, "one", "yaml").returns("/nonexisting/one.yaml").times(3)
+
+          YAML.expects(:load_file).with("/nonexisting/one.yaml").returns(YAML.load("---\nstringval: 'string'\nboolval: true\nnumericval: 1")).times(3)
+
+          @backend.lookup("stringval", {}, nil, :priority).should == "string"
+          @backend.lookup("boolval", {}, nil, :priority).should == true
+          @backend.lookup("numericval", {}, nil, :priority).should == 1
+        end
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/spec/unit/backend_spec.rb
+++ b/lib/hiera-gem/spec/unit/backend_spec.rb
@@ -1,0 +1,282 @@
+require 'spec_helper'
+
+class Hiera
+  describe Backend do
+    describe "#datadir" do
+      it "should use the backend configured dir" do
+        Config.load({:rspec => {:datadir => "/tmp"}})
+        Backend.expects(:parse_string).with("/tmp", {})
+        Backend.datadir(:rspec, {})
+      end
+
+      it "should default to /var/lib/hiera" do
+        Config.load({})
+        Backend.expects(:parse_string).with("/var/lib/hiera", {})
+        Backend.datadir(:rspec, {})
+      end
+    end
+
+    describe "#empty_anwer" do
+      it "should return [] for array searches" do
+        Backend.empty_answer(:array).should == []
+      end
+
+      it "should return {} for hash searches" do
+        Backend.empty_answer(:hash).should == {}
+      end
+
+      it "should return nil otherwise" do
+        Backend.empty_answer(:meh).should == nil
+      end
+    end
+
+    describe "#datafile" do
+      it "should check if the file exist and return nil if not" do
+        Hiera.expects(:debug).with("Cannot find datafile /nonexisting/test.yaml, skipping")
+        Backend.expects(:datadir).returns("/nonexisting")
+        Backend.datafile(:yaml, {}, "test", "yaml").should == nil
+      end
+
+      it "should return the correct file name" do
+        Backend.expects(:datadir).returns("/nonexisting")
+        File.expects(:exist?).with("/nonexisting/test.yaml").returns(true)
+        Backend.datafile(:yaml, {}, "test", "yaml").should == "/nonexisting/test.yaml"
+      end
+    end
+
+    describe "#datasources" do
+      it "should use the supplied hierarchy" do
+        expected = ["one", "two"]
+        Backend.datasources({}, nil, ["one", "two"]) do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+
+      it "should use the configured hierarchy if none is supplied" do
+        Config.load(:hierarchy => "test")
+
+        Backend.datasources({}) do |backend|
+          backend.should == "test"
+        end
+      end
+
+      it "should default to common if not configured or supplied" do
+        Config.load({})
+
+        Backend.datasources({}) do |backend|
+          backend.should == "common"
+        end
+      end
+
+      it "should insert the override if provided" do
+        Config.load({})
+
+        expected = ["override", "common"]
+        Backend.datasources({}, "override") do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+
+      it "should parse the sources based on scope" do
+        Backend.expects(:parse_string).with("common", {:rspec => :tests})
+        Backend.datasources({:rspec => :tests}) { }
+      end
+
+      it "should not return empty sources" do
+        Config.load({})
+
+        expected = ["common"]
+        Backend.datasources({}, "%{rspec}") do |backend|
+          backend.should == expected.delete_at(0)
+        end
+
+        expected.empty?.should == true
+      end
+    end
+
+    describe "#parse_string" do
+      it "should not try to parse invalid data" do
+        Backend.parse_string(nil, {}).should == nil
+      end
+
+      it "should clone the supplied data" do
+        data = ""
+        data.expects(:clone).returns("")
+        Backend.parse_string(data, {})
+      end
+
+      it "should only parse string data" do
+        data = ""
+        data.expects(:is_a?).with(String)
+        Backend.parse_string(data, {})
+      end
+
+      it "should match data from scope" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should match data from extra_data" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {}, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should prefer scope over extra_data" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => "test"}, {"rspec" => "fail"}).should == "test_test_test"
+      end
+
+      it "should treat :undefined in scope as empty" do
+        input = "test_%{rspec}_test"
+        Backend.parse_string(input, {"rspec" => :undefined}).should == "test__test"
+      end
+    end
+
+    describe "#parse_answer" do
+      it "should parse strings correctly" do
+        input = "test_%{rspec}_test"
+        Backend.parse_answer(input, {"rspec" => "test"}).should == "test_test_test"
+      end
+
+      it "should parse each string in an array" do
+        input = ["test_%{rspec}_test", "test_%{rspec}_test", ["test_%{rspec}_test"]]
+        Backend.parse_answer(input, {"rspec" => "test"}).should == ["test_test_test", "test_test_test", ["test_test_test"]]
+      end
+
+      it "should parse each string in a hash" do
+        input = {"foo" => "test_%{rspec}_test", "bar" => "test_%{rspec}_test"}
+        Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>"test_test_test"}
+      end
+
+      it "should parse mixed arrays and hashes" do
+        input = {"foo" => "test_%{rspec}_test", "bar" => ["test_%{rspec}_test", "test_%{rspec}_test"]}
+        Backend.parse_answer(input, {"rspec" => "test"}).should == {"foo"=>"test_test_test", "bar"=>["test_test_test", "test_test_test"]}
+      end
+
+      it "should parse integers correctly" do
+        input = 1
+        Backend.parse_answer(input, {"rspec" => "test"}).should == 1
+      end
+
+      it "should parse floats correctly" do
+        input = 0.233
+        Backend.parse_answer(input, {"rspec" => "test"}).should == 0.233
+      end
+
+      it "should parse true boolean values correctly" do
+        input = true
+        Backend.parse_answer(input, {"rspec" => "test"}).should == true
+      end
+
+      it "should parse false boolean values correctly" do
+        input = false
+        Backend.parse_answer(input, {"rspec" => "test"}).should == false
+      end
+    end
+
+    describe "#resolve_answer" do
+      it "should correctly parse array data" do
+        Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :array).should == ["foo", "bar"]
+      end
+
+      it "should just return the answer for non array data" do
+        Backend.resolve_answer(["foo", ["foo", "foo"], "bar"], :priority).should == ["foo", ["foo", "foo"], "bar"]
+      end
+    end
+
+    describe "#lookup" do
+      before do
+        Hiera.stubs(:debug)
+        Hiera.stubs(:warn)
+      end
+
+      it "should cache backends" do
+        Hiera.expects(:debug).with(regexp_matches(/Hiera YAML backend starting/)).once
+
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend.lookup("key", "default", {}, nil, nil)
+        Backend.lookup("key", "default", {}, nil, nil)
+      end
+
+      it "should return the answer from the backend" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil).returns("answer")
+
+        Backend.lookup("key", "default", {}, nil, nil).should == "answer"
+      end
+
+      it "should retain the datatypes as returned by the backend" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("stringval", {}, nil, nil).returns("string")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("boolval", {}, nil, nil).returns(false)
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("numericval", {}, nil, nil).returns(1)
+
+        Backend.lookup("stringval", "default", {}, nil, nil).should == "string"
+        Backend.lookup("boolval", "default", {}, nil, nil).should == false
+        Backend.lookup("numericval", "default", {}, nil, nil).should == 1
+      end
+
+      it "should call to all backends till an answer is found" do
+        backend = mock
+        backend.expects(:lookup).returns("answer")
+        Config.load({})
+        Config.instance_variable_set("@config", {:backends => ["yaml", "rspec"]})
+        Backend.instance_variable_set("@backends", {"rspec" => backend})
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
+        Backend.expects(:constants).returns(["Yaml_backend", "Rspec_backend"]).twice
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "answer"
+      end
+
+      it "should parse the answers based on resolution_type" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend.expects(:resolve_answer).with("test_test", :priority).returns("parsed")
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, :priority).returns("test_test")
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, :priority).should == "parsed"
+      end
+
+      it "should return the default with variables parsed if nothing is found" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {"rspec" => "test"}, nil, nil)
+
+        Backend.lookup("key", "test_%{rspec}", {"rspec" => "test"}, nil, nil).should == "test_test"
+      end
+
+      it "should correctly handle string default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, nil)
+        Backend.lookup("key", "test", {}, nil, nil).should == "test"
+      end
+
+      it "should correctly handle array default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :array)
+        Backend.lookup("key", ["test"], {}, nil, :array).should == ["test"]
+      end
+
+      it "should correctly handle hash default data" do
+        Config.load({:yaml => {:datadir => "/tmp"}})
+        Config.load_backends
+        Backend::Yaml_backend.any_instance.expects(:lookup).with("key", {}, nil, :hash)
+        Backend.lookup("key", {"test" => "value"}, {}, nil, :hash).should == {"test" => "value"}
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/spec/unit/config_spec.rb
+++ b/lib/hiera-gem/spec/unit/config_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+class Hiera
+  describe Config do
+    describe "#load" do
+      it "should treat string sources as a filename" do
+        expect {
+            Config.load("/nonexisting")
+        }.to raise_error("Config file /nonexisting not found")
+      end
+
+      it "should raise error for missing config files" do
+        File.expects(:exist?).with("/nonexisting").returns(false)
+        YAML.expects(:load_file).with("/nonexisting").never
+
+        expect { Config.load("/nonexisting") }.should raise_error RuntimeError, /not found/
+      end
+
+      it "should attempt to YAML load config files" do
+        File.expects(:exist?).with("/nonexisting").returns(true)
+        YAML.expects(:load_file).with("/nonexisting").returns(YAML.load("---\n"))
+
+        Config.load("/nonexisting")
+      end
+
+      it "should use defaults on empty YAML config file" do
+        File.expects(:exist?).with("/nonexisting").returns(true)
+        YAML.expects(:load_file).with("/nonexisting").returns(YAML.load(""))
+
+        Config.load("/nonexisting").should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
+      end
+
+      it "should use hash data as source if supplied" do
+        config = Config.load({"rspec" => "test"})
+        config["rspec"].should == "test"
+      end
+
+      it "should merge defaults with the loaded or supplied config" do
+        config = Config.load({})
+        config.should == {:backends => ["yaml"], :hierarchy => "common", :logger => "console"}
+      end
+
+      it "should force :backends to be a flattened array" do
+        Config.load({:backends => [["foo", ["bar"]]]}).should == {:backends => ["foo", "bar"], :hierarchy => "common", :logger => "console"}
+      end
+
+      it "should load the supplied logger" do
+        Hiera.expects(:logger=).with("foo")
+        Config.load({:logger => "foo"})
+      end
+
+      it "should default to the console logger" do
+        Hiera.expects(:logger=).with("console")
+        Config.load({})
+      end
+    end
+
+    describe "#load_backends" do
+      it "should load each backend" do
+        Config.load(:backends => ["One", "Two"])
+        Config.expects(:require).with("hiera/backend/one_backend")
+        Config.expects(:require).with("hiera/backend/two_backend")
+        Config.load_backends
+      end
+
+      it "should warn if it cant load a backend" do
+        Config.load(:backends => ["one"])
+        Config.expects(:require).with("hiera/backend/one_backend").raises("fail")
+
+        expect {
+            Config.load_backends
+        }.to raise_error("fail")
+      end
+    end
+
+    describe "#include?" do
+      it "should correctly report inclusion" do
+        Config.load({})
+        Config.include?(:foo).should == false
+        Config.include?(:logger).should == true
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/spec/unit/console_logger_spec.rb
+++ b/lib/hiera-gem/spec/unit/console_logger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+class Hiera
+  describe Console_logger do
+    describe "#warn" do
+      it "should warn to STDERR" do
+        STDERR.expects(:puts).with("WARN: 0: foo")
+        Time.expects(:now).returns(0)
+        Console_logger.warn("foo")
+      end
+
+      it "should debug to STDERR" do
+        STDERR.expects(:puts).with("DEBUG: 0: foo")
+        Time.expects(:now).returns(0)
+        Console_logger.debug("foo")
+      end
+    end
+  end
+end

--- a/lib/hiera-gem/spec/unit/hiera_spec.rb
+++ b/lib/hiera-gem/spec/unit/hiera_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe "Hiera" do
+  describe "#logger=" do
+    it "should attempt to load the supplied logger" do
+      Hiera.stubs(:warn)
+      Hiera.expects(:require).with("hiera/foo_logger").raises("fail")
+      Hiera.logger = "foo"
+    end
+
+    it "should fall back to the Console logger on failure" do
+      Hiera.expects(:warn).with("Failed to load foo logger: LoadError: no such file to load -- hiera/foo_logger")
+      Hiera.logger = "foo"
+    end
+  end
+
+  describe "#warn" do
+    it "should call the supplied logger" do
+      Hiera::Console_logger.expects(:warn).with("rspec")
+      Hiera.warn("rspec")
+    end
+  end
+
+  describe "#debug" do
+    it "should call the supplied logger" do
+      Hiera::Console_logger.expects(:debug).with("rspec")
+      Hiera.debug("rspec")
+    end
+  end
+
+  describe "#initialize" do
+    it "should default to /etc/hiera.yaml for config" do
+      Hiera::Config.expects(:load).with("/etc/hiera.yaml")
+      Hiera::Config.stubs(:load_backends)
+      Hiera.new
+    end
+
+    it "should pass the supplied config to the config class" do
+      Hiera::Config.expects(:load).with({"test" => "rspec"})
+      Hiera::Config.stubs(:load_backends)
+      Hiera.new(:config => {"test" => "rspec"})
+    end
+
+    it "should load all backends on start" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.expects(:load_backends)
+      Hiera.new
+    end
+  end
+
+  describe "#lookup" do
+    it "should proxy to the Backend#lookup method" do
+      Hiera::Config.stubs(:load)
+      Hiera::Config.stubs(:load_backends)
+      Hiera::Backend.expects(:lookup).with(:key, :default, :scope, :order_override, :resolution_type)
+      Hiera.new.lookup(:key, :default, :scope, :order_override, :resolution_type)
+    end
+  end
+end

--- a/lib/hiera-gem/tasks/release.rb
+++ b/lib/hiera-gem/tasks/release.rb
@@ -1,0 +1,34 @@
+
+VERSION_FILE = 'lib/hiera.rb'
+
+def get_current_version
+  File.open( VERSION_FILE ) {|io| io.grep(/VERSION = /)}[0].split()[-1]
+end
+
+def described_version
+  # This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
+  %x{git describe}.gsub('-', '.').split('.')[0..3].join('.').to_s.gsub('v', '')
+end
+
+namespace :pkg do
+
+  desc "Bump version prior to release (internal task)"
+  task :versionbump  do
+    old_version =  get_current_version
+    contents = IO.read(VERSION_FILE)
+    new_version = '"' + described_version.to_s.strip + '"'
+    contents.gsub!("VERSION = #{old_version}", "VERSION = #{new_version}")
+    file = File.open(VERSION_FILE, 'w')
+    file.write contents
+    file.close
+  end
+
+  desc "Build Package"
+  task :release => [ :versionbump, :default ] do
+    Rake::Task[:package].invoke
+  end
+
+end # namespace
+
+task :clean => [ :clobber_package ] do
+end

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -22,8 +22,26 @@ module Puppet::Parser::Functions
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
-        require 'hiera'
-        require 'hiera/scope'
+        begin
+          # Try normal gem loading
+          require 'hiera'
+          require 'hiera/scope'
+        rescue LoadError
+          # If this fails revert to the gem inside this module
+          hiera_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','hiera-gem','lib'))
+          Puppet.warning("Loading hiera gem from inside the hiera-puppet module")
+
+          # Add the load path for loading hiera.rb
+          $LOAD_PATH.unshift(hiera_gem_path) unless $LOAD_PATH.include?(hiera_gem_path)
+          require 'hiera'
+          Puppet.debug("Hiera Gem Path added: #{hiera_gem_path}")
+
+          # Add the load path for loading hiera/scope.rb
+          hiera_scope_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..'))
+          $LOAD_PATH.unshift(hiera_scope_gem_path) unless $LOAD_PATH.include?(hiera_scope_gem_path)
+          require 'hiera/scope'
+          Puppet.debug("Hiera Scope Gem Path added: #{hiera_scope_gem_path}")
+        end
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -17,7 +17,14 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+       # Check if hiera_configfile is set via a global puppet variable
+       global_var_configdir = File.join(lookupvar("hiera_configdir"))
+       if global_var_configdir != ""
+         configfile = File.expand_path(File.join(global_var_configdir, "hiera.yaml"))
+         Puppet.warning("Overriding Hiera Config Directory to #{configfile}")
+       else
+         configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+       end
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
@@ -45,6 +52,13 @@ module Puppet::Parser::Functions
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"
+
+        # Add yaml dataconfiguration dir to the configuration
+        global_var_yaml_datadir = File.join(lookupvar("hiera_yaml_datadir"))
+        if global_var_yaml_datadir !=""
+          config[:yaml] = Hash.new if config[:yaml].nil?
+          config[:yaml][:datadir] = global_var_yaml_datadir
+        end
 
         hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -13,8 +13,26 @@ module Puppet::Parser::Functions
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
-        require 'hiera'
-        require 'hiera/scope'
+         begin
+           # Try normal gem loading
+           require 'hiera'
+           require 'hiera/scope'
+         rescue LoadError
+           # If this fails revert to the gem inside this module
+           hiera_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','hiera-gem','lib'))
+           Puppet.warning("Loading hiera gem from inside the hiera-puppet module")
+
+           # Add the load path for loading hiera.rb
+           $LOAD_PATH.unshift(hiera_gem_path) unless $LOAD_PATH.include?(hiera_gem_path)
+           require 'hiera'
+           Puppet.debug("Hiera Gem Path added: #{hiera_gem_path}")
+
+           # Add the load path for loading hiera/scope.rb
+           hiera_scope_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..'))
+           $LOAD_PATH.unshift(hiera_scope_gem_path) unless $LOAD_PATH.include?(hiera_scope_gem_path)
+           require 'hiera/scope'
+           Puppet.debug("Hiera Scope Gem Path added: #{hiera_scope_gem_path}")
+         end
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -10,7 +10,14 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        # Check if hiera_configfile is set via a global puppet variable
+        global_var_configdir = File.join(lookupvar("hiera_configdir"))
+        if global_var_configdir != ""
+          configfile = File.expand_path(File.join(global_var_configdir, "hiera.yaml"))
+          Puppet.warning("Overriding Hiera Config Directory to #{configfile}")
+        else
+          configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        end
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
@@ -38,6 +45,13 @@ module Puppet::Parser::Functions
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"
+
+        # Add yaml dataconfiguration dir to the configuration
+        global_var_yaml_datadir = File.join(lookupvar("hiera_yaml_datadir"))
+        if global_var_yaml_datadir !=""
+          config[:yaml] = Hash.new if config[:yaml].nil?
+          config[:yaml][:datadir] = global_var_yaml_datadir
+        end
 
         hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -13,8 +13,26 @@ module Puppet::Parser::Functions
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
         raise(Puppet::ParseError, "You need rubygems to use Hiera") unless Puppet.features.rubygems?
 
-        require 'hiera'
-        require 'hiera/scope'
+       begin
+         # Try normal gem loading
+         require 'hiera'
+         require 'hiera/scope'
+       rescue LoadError
+         # If this fails revert to the gem inside this module
+         hiera_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','hiera-gem','lib'))
+         Puppet.warning("Loading hiera gem from inside the hiera-puppet module")
+
+         # Add the load path for loading hiera.rb
+         $LOAD_PATH.unshift(hiera_gem_path) unless $LOAD_PATH.include?(hiera_gem_path)
+         require 'hiera'
+         Puppet.debug("Hiera Gem Path added: #{hiera_gem_path}")
+
+         # Add the load path for loading hiera/scope.rb
+         hiera_scope_gem_path = File.expand_path(File.join(File.dirname(__FILE__),'..','..','..'))
+         $LOAD_PATH.unshift(hiera_scope_gem_path) unless $LOAD_PATH.include?(hiera_scope_gem_path)
+         require 'hiera/scope'
+         Puppet.debug("Hiera Scope Gem Path added: #{hiera_scope_gem_path}")
+       end
 
         config = YAML.load_file(configfile)
         config[:logger] = "puppet"


### PR DESCRIPTION
1) Makes it easy to use hiera even if adding extra gems can not be installed easily. 
This helps in the transition path to use hiera.
- For easy maintenance the hiera gem contents can be copied in hiera-gem subdirectory.
- If the gem is available it will use the gem version.

2) Adds support for overriding/relocating (useful in Vagrant testing)
$hiera_configdir  and $hiera_yaml_datadir 
