### PR TITLE
(#13684) Add safe_hiera function that accepts defaults

### DIFF
--- a/lib/puppet/parser/functions/safe_hiera.rb
+++ b/lib/puppet/parser/functions/safe_hiera.rb
@@ -1,0 +1,24 @@
+#
+# safe_hiera.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:safe_hiera, :type => :rvalue, :doc => <<-EOS
+Calls hiera, but fails gracefully if hiera is misconfigured.
+    EOS
+  ) do |arguments|
+
+    if arguments[1]
+      begin
+        function_hiera(arguments[0])
+      rescue
+        arguments[1]
+      end
+    else
+      function_hiera(arguments[0])
+    end
+
+  end
+end
+
+# vim: set ts=2 sw=2 et :


### PR DESCRIPTION
Adds a :safe_heira function that accepts safe_hiera('key','default') and
returns default even if hiera is misconfigured.  It allows hiera to fail
and passes through the error message if no default is defined.
