### PR TITLE
(#14841) Give useful error for array or hash lookup failure

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
+require 'puppetlabs_spec_helper/rake_tasks'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -18,7 +18,7 @@ RUBYLIB=$(BUILD_ROOT)/$(LIBDIR)
 BIN_DIR=$(BUILD_ROOT)/usr/bin
 DOC_DIR=$(BUILD_ROOT)/usr/share/doc/hiera-puppet/
 
-install/hiera::
+install/hiera-puppet::
 	mkdir -p  $(RUBYLIB)
 	mkdir -p  $(BIN_DIR)
 	mkdir -p  $(DOC_DIR)

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -13,6 +13,8 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
+        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
+
         key = args[0]
         default = args[1]
         override = args[2]

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -4,6 +4,8 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
+        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
+
         key = args[0]
         default = args[1]
         override = args[2]

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -28,7 +28,7 @@ module Puppet::Parser::Functions
 
         answer = hiera.lookup(key, default, hiera_scope, override, :array)
 
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
         answer
     end

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -30,7 +30,7 @@ module Puppet::Parser::Functions
 
         answer = hiera.lookup(key, default, hiera_scope, override, :hash)
 
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
         answer
     end

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -4,6 +4,8 @@ module Puppet::Parser::Functions
             args = args[0]
         end
 
+        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
+
         key = args[0]
         default = args[1]
         override = args[2]

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -28,7 +28,7 @@ module Puppet::Parser::Functions
 
         answer = hiera.lookup(key, default, hiera_scope, override, :array)
 
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
         method = Puppet::Parser::Functions.function(:include)
         send(method, answer)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $:.insert(0, File.join([File.dirname(__FILE__), "..", "..", "lib"]))
 
 require 'rubygems'
 require 'rspec'
+require 'puppetlabs_spec_helper/module_spec_helper'
 require 'hiera/backend/puppet_backend'
 require 'hiera/scope'
 require 'rspec/mocks'

--- a/spec/unit/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/parser/functions/hiera_array_spec.rb
@@ -1,0 +1,22 @@
+require 'puppet'
+require 'hiera'
+require 'spec_helper'
+
+describe 'Puppet::Parser::Functions#hiera_array' do
+  before do
+    Puppet::Parser::Functions.function(:hiera_array)
+    @scope = Puppet::Parser::Scope.new
+    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
+    File.stubs(:exist?).with(configfile).returns true
+    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
+  end
+
+  it 'should require a key argument' do
+    expect { @scope.function_hiera_array([]) }.should raise_error(Puppet::ParseError)
+  end
+
+  it 'should raise a useful error when nil is returned' do
+    Hiera.any_instance.expects(:lookup).returns(nil)
+    expect { @scope.function_hiera_array("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+  end
+end

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -3,9 +3,20 @@ require 'hiera'
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera_hash' do
-  it 'should require a key argument' do
+  before do
     Puppet::Parser::Functions.function(:hiera_hash)
     @scope = Puppet::Parser::Scope.new
+    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
+    File.stubs(:exist?).with(configfile).returns true
+    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
+  end
+
+  it 'should require a key argument' do
     expect { @scope.function_hiera_hash([]) }.should raise_error(Puppet::ParseError)
+  end
+
+  it 'should raise a useful error when nil is returned' do
+    Hiera.any_instance.expects(:lookup).returns(nil)
+    expect { @scope.function_hiera_hash("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 end

--- a/spec/unit/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/parser/functions/hiera_include_spec.rb
@@ -1,0 +1,22 @@
+require 'puppet'
+require 'hiera'
+require 'spec_helper'
+
+describe 'Puppet::Parser::Functions#hiera_include' do
+  before do
+    Puppet::Parser::Functions.function(:hiera_include)
+    @scope = Puppet::Parser::Scope.new
+    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
+    File.stubs(:exist?).with(configfile).returns true
+    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
+  end
+
+  it 'should require a key argument' do
+    expect { @scope.function_hiera_include([]) }.should raise_error(Puppet::ParseError)
+  end
+
+  it 'should raise a useful error when nil is returned' do
+    Hiera.any_instance.expects(:lookup).returns(nil)
+    expect { @scope.function_hiera_include("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+  end
+end

--- a/spec/unit/parser/functions/hiera_spec.rb
+++ b/spec/unit/parser/functions/hiera_spec.rb
@@ -1,0 +1,22 @@
+require 'puppet'
+require 'hiera'
+require 'spec_helper'
+
+describe 'Puppet::Parser::Functions#hiera' do
+  before do
+    Puppet::Parser::Functions.function(:hiera)
+    @scope = Puppet::Parser::Scope.new
+    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
+    File.stubs(:exist?).with(configfile).returns true
+    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
+  end
+
+  it 'should require a key argument' do
+    expect { @scope.function_hiera([]) }.should raise_error(Puppet::ParseError)
+  end
+
+  it 'should raise a useful error when nil is returned' do
+    Hiera.any_instance.expects(:lookup).returns(nil)
+    expect { @scope.function_hiera("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+  end
+end

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -109,6 +109,7 @@ namespace :package do
         begin
           sh dsc_cmd
           deb_cmd = "sudo cowbuilder --build #{latest_file(File.join(temp, '*.dsc'))} --basepath /var/cache/pbuilder/#{@cow}/"
+	        sh deb_cmd
           result_dir = "/var/cache/pbuilder/result"
           dest_dir = File.join(@build_root, 'pkg', 'deb')
           mkdir_p dest_dir


### PR DESCRIPTION
Don't just throw a NoMethodError when using hiera_array or hiera_hash when nil is returned.
