### PR TITLE
(maint) Follow Puppet Labs style guide + code cleanup

### DIFF
--- a/acceptance/tests/parser_functions/hiera/00-setup.rb
+++ b/acceptance/tests/parser_functions/hiera/00-setup.rb
@@ -1,0 +1,27 @@
+test_name "Setup for hiera parser function"
+
+apply_manifest_on master, <<-PP
+file { '/etc/puppet/hiera.yaml':
+  ensure  => present,
+  content => '---
+    :backends:
+      - "yaml"
+    :logger: "console"
+    :hierarchy:
+      - "%{fqdn}"
+      - "%{environment}"
+      - "global"
+
+    :yaml:
+      :datadir: "/var/lib/hiera"
+  '
+}
+
+file { '/var/lib/hiera':
+  ensure  => directory,
+  recurse => true,
+  purge   => true,
+  force   => true,
+}
+PP
+

--- a/acceptance/tests/parser_functions/hiera/01-lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/01-lookup_data.rb
@@ -1,0 +1,64 @@
+begin test_name "Lookup data using the hiera parser function"
+
+step 'Setup'
+apply_manifest_on master, <<-PP
+file { '/var/lib/hiera/global.yaml':
+  ensure  => present,
+  content => "---
+    port: 8080
+  "
+}
+PP
+
+testdir = master.tmpdir('hiera')
+
+create_remote_file(master, "#{testdir}/puppet.conf", <<END)
+[main]
+  manifest   = "#{testdir}/site.pp"
+  modulepath = "#{testdir}/modules"
+END
+
+on master, "mkdir -p #{testdir}/modules/apache/manifests"
+
+agent_names = agents.map { |agent| "'#{agent.to_s}'" }.join(', ')
+create_remote_file(master, "#{testdir}/site.pp", <<-PP)
+node default {
+  include apache
+}
+PP
+
+create_remote_file(master, "#{testdir}/modules/apache/manifests/init.pp", <<-PP)
+class apache {
+  $port = hiera('port')
+
+  notify { "port from hiera":
+    message => "apache server port: ${port}"
+  }
+}
+PP
+
+on master, "chown -R root:puppet #{testdir}"
+on master, "chmod -R g+rwX #{testdir}"
+
+
+step "Try to lookup string data"
+
+with_master_running_on(master, "--config #{testdir}/puppet.conf --debug --verbose --daemonize --dns_alt_names=\"puppet,$(hostname -s),$(hostname -f)\" --autosign true") do
+  agents.each do |agent|
+    run_agent_on(agent, "--no-daemonize --onetime --verbose --server #{master}")
+
+    assert_match("apache server port: 8080", stdout)
+  end
+end
+
+
+ensure step "Teardown"
+apply_manifest_on master, <<-PP
+file { '/var/lib/hiera':
+  ensure  => directory,
+  recurse => true,
+  purge   => true,
+  force   => true,
+}
+PP
+end

--- a/bin/extlookup2hiera
+++ b/bin/extlookup2hiera
@@ -6,51 +6,51 @@ require 'csv'
 options = {:in => nil, :out => nil, :format => :yaml}
 
 OptionParser.new do |opts|
-    opts.banner = "Converter for extlookup CSV files into Hiera JSON and YAML files"
+  opts.banner = "Converter for extlookup CSV files into Hiera JSON and YAML files"
 
-    opts.on("--in FILE", "-i", "Input CSV file") do |v|
-        options[:in] = v
-    end
+  opts.on("--in FILE", "-i", "Input CSV file") do |v|
+    options[:in] = v
+  end
 
-    opts.on("--out FILE", "-o", "Output Hiera file") do |v|
-        options[:out] = v
-    end
+  opts.on("--out FILE", "-o", "Output Hiera file") do |v|
+    options[:out] = v
+  end
 
-    opts.on("--json", "-j", "Create JSON format file") do |v|
-        options[:format] = :json
-    end
+  opts.on("--json", "-j", "Create JSON format file") do |v|
+    options[:format] = :json
+  end
 end.parse!
 
 if options[:in].nil? || options[:out].nil?
-    STDERR.puts "Please specify an input and output file with --in and --out"
-    exit 1
+  STDERR.puts "Please specify an input and output file with --in and --out"
+  exit 1
 end
 
 unless File.exist?(options[:in])
-    STDERR.puts "Cannot find input file #{options[:in]}"
-    exit 1
+  STDERR.puts "Cannot find input file #{options[:in]}"
+  exit 1
 end
 
 csvdata = CSV.read(options[:in])
 hieradata = {}
 
 csvdata.each do |d|
-    d = d.map{|item| item.to_s}
+  d = d.map{|item| item.to_s}
 
-    if d.size > 2
-        hieradata[d[0]] = d[1, d.size].flatten
-    else
-        hieradata[d[0]] = d[1]
-    end
+  if d.size > 2
+    hieradata[d[0]] = d[1, d.size].flatten
+  else
+    hieradata[d[0]] = d[1]
+  end
 end
 
 case options[:format]
 when :yaml
-    require 'yaml'
-    File.open(options[:out], "w") {|f| f.write hieradata.to_yaml}
-
+  require 'yaml'
+  File.open(options[:out], "w") {|f| f.write hieradata.to_yaml}
 when :json
-    require 'rubygems'
-    require 'json'
-    File.open(options[:out], "w") {|f| f.write JSON.pretty_generate hieradata}
+  require 'rubygems'
+  require 'json'
+  File.open(options[:out], "w") {|f| f.write JSON.pretty_generate hieradata}
 end
+

--- a/example/etc/hiera.yaml
+++ b/example/etc/hiera.yaml
@@ -1,10 +1,12 @@
 ---
-:backends: - yaml
-           - puppet
-:hierarchy: - %{location}
-            - %{environment}
-            - common
+:backends:
+  - yaml
+  - puppet
+:hierarchy:
+  - %{location}
+  - %{environment}
+  - common
 :yaml:
-        :datadir: etc/hieradb
+  :datadir: etc/hieradb
 :puppet:
-        :datasource: data
+  :datasource: data

--- a/example/etc/hieradb/common.yaml
+++ b/example/etc/hieradb/common.yaml
@@ -1,2 +1,3 @@
-classes: - users::common
-         - ntp::config
+classes:
+  - users::common
+  - ntp::config

--- a/example/etc/hieradb/dc1.yaml
+++ b/example/etc/hieradb/dc1.yaml
@@ -1,4 +1,6 @@
 ---
-ntpservers: - ntp1.dc1.example.com
-            - ntp2.dc1.example.com
-classes: - users::dc1
+ntpservers:
+  - ntp1.dc1.example.com
+  - ntp2.dc1.example.com
+classes:
+  - users::dc1

--- a/example/etc/puppet.conf
+++ b/example/etc/puppet.conf
@@ -1,2 +1,3 @@
 [main]
-    modulepath          = modules
+  modulepath = modules
+

--- a/example/modules/data/manifests/common.pp
+++ b/example/modules/data/manifests/common.pp
@@ -1,3 +1,3 @@
 class data::common {
-   $ntpservers = ["ntp1.example.com", "ntp2.example.com"]
+  $ntpservers = ["ntp1.example.com", "ntp2.example.com"]
 }

--- a/example/modules/ntp/manifests/config.pp
+++ b/example/modules/ntp/manifests/config.pp
@@ -1,5 +1,5 @@
 class ntp::config($ntpservers = hiera("ntpservers")) {
-    file{"/tmp/ntp.conf":
-        content => template("ntp/ntp.conf.erb")
-    }
+  file{"/tmp/ntp.conf":
+    content => template("ntp/ntp.conf.erb")
+  }
 }

--- a/example/modules/ntp/manifests/data.pp
+++ b/example/modules/ntp/manifests/data.pp
@@ -1,3 +1,3 @@
 class ntp::data {
-    $ntpservers = ["1.pool.ntp.org", "2.pool.ntp.org"]
+  $ntpservers = ["1.pool.ntp.org", "2.pool.ntp.org"]
 }

--- a/example/modules/users/manifests/common.pp
+++ b/example/modules/users/manifests/common.pp
@@ -1,3 +1,3 @@
 class users::common {
-    notify{"Adding users::common": }
+  notify{"Adding users::common": }
 }

--- a/example/modules/users/manifests/dc1.pp
+++ b/example/modules/users/manifests/dc1.pp
@@ -1,3 +1,3 @@
 class users::dc1 {
-    notify{"Adding users::dc1": }
+  notify{"Adding users::dc1": }
 }

--- a/example/modules/users/manifests/development.pp
+++ b/example/modules/users/manifests/development.pp
@@ -1,3 +1,3 @@
 class users::development {
-    notify{"Adding users::development": }
+  notify{"Adding users::development": }
 }

--- a/example/site.pp
+++ b/example/site.pp
@@ -1,3 +1,3 @@
 node default {
-    hiera_include("classes")
+  hiera_include("classes")
 }

--- a/lib/hiera/backend/puppet_backend.rb
+++ b/lib/hiera/backend/puppet_backend.rb
@@ -1,94 +1,102 @@
 class Hiera
-    module Backend
-        class Puppet_backend
-            def initialize
-                Hiera.debug("Hiera Puppet backend starting")
-            end
+  module Backend
+    class Puppet_backend
+      def initialize
+        Hiera.debug("Hiera Puppet backend starting")
+      end
 
-            def hierarchy(scope, override)
-                begin
-                    data_class = Config[:puppet][:datasource] || "data"
-                rescue
-                    data_class = "data"
-                end
-
-                calling_class = scope.resource.name.to_s.downcase
-                calling_module = calling_class.split("::").first
-
-                hierarchy = Config[:hierarchy] || [calling_class, calling_module]
-
-                hierarchy = [hierarchy].flatten.map do |klass|
-                    klass = Backend.parse_string(klass, scope, {"calling_class" => calling_class, "calling_module" => calling_module})
-
-                    next if klass == ""
-
-                    [data_class, klass].join("::")
-                end.compact
-
-                hierarchy << [calling_class, data_class].join("::")
-                hierarchy << [calling_module, data_class].join("::") unless calling_module == calling_class
-
-                hierarchy.insert(0, [data_class, override].join("::")) if override
-
-                hierarchy
-            end
-
-            def lookup(key, scope, order_override, resolution_type)
-                answer = nil
-
-                Hiera.debug("Looking up #{key} in Puppet backend")
-
-                include_class = Puppet::Parser::Functions.function(:include)
-                loaded_classes = scope.catalog.classes
-
-                hierarchy(scope, order_override).each do |klass|
-                    Hiera.debug("Looking for data in #{klass}")
-
-                    varname = [klass, key].join("::")
-                    temp_answer = nil
-
-                    unless loaded_classes.include?(klass)
-                        begin
-                            if scope.respond_to?(:function_include)
-                                scope.function_include(klass)
-                            else
-                                scope.real.function_include(klass)
-                            end
-
-                            temp_answer = scope[varname]
-                            Hiera.debug("Found data in class #{klass}")
-                        rescue
-                        end
-                    else
-                        temp_answer = scope[varname]
-                    end
-
-                    next if temp_answer == :undefined
-
-                    if temp_answer
-                        # for array resolution we just append to the array whatever
-                        # we find, we then goes onto the next file and keep adding to
-                        # the array
-                        #
-                        # for priority searches we break after the first found data item
-                        case resolution_type
-                        when :array
-                            answer ||= []
-                            answer << Backend.parse_answer(temp_answer, scope)
-                        when :hash
-                            answer ||= {}
-                            answer = Backend.parse_answer(temp_answer, scope).merge answer
-                        else
-                            answer = Backend.parse_answer(temp_answer, scope)
-                            break
-                        end
-                    end
-                end
-
-                answer = nil if answer == :undefined
-
-                answer
-            end
+      def hierarchy(scope, override)
+        begin
+          data_class = Config[:puppet][:datasource] || "data"
+        rescue
+          data_class = "data"
         end
+
+        calling_class = scope.resource.name.to_s.downcase
+        calling_module = calling_class.split("::").first
+
+        hierarchy = Config[:hierarchy] || [calling_class, calling_module]
+
+        hierarchy = [hierarchy].flatten.map do |klass|
+          klass = Backend.parse_string(klass, scope,
+            {
+              "calling_class"  => calling_class,
+              "calling_module" => calling_module
+            }
+          )
+
+          next if klass == ""
+
+          [data_class, klass].join("::")
+        end.compact
+
+        hierarchy << [calling_class, data_class].join("::")
+
+        unless calling_module == calling_class
+          hierarchy << [calling_module, data_class].join("::")
+        end
+
+        hierarchy.insert(0, [data_class, override].join("::")) if override
+
+        hierarchy
+      end
+
+      def lookup(key, scope, order_override, resolution_type)
+        answer = nil
+
+        Hiera.debug("Looking up #{key} in Puppet backend")
+
+        include_class = Puppet::Parser::Functions.function(:include)
+        loaded_classes = scope.catalog.classes
+
+        hierarchy(scope, order_override).each do |klass|
+          Hiera.debug("Looking for data in #{klass}")
+
+          varname = [klass, key].join("::")
+          temp_answer = nil
+
+          unless loaded_classes.include?(klass)
+            begin
+              if scope.respond_to?(:function_include)
+                scope.function_include(klass)
+              else
+                scope.real.function_include(klass)
+              end
+
+              temp_answer = scope[varname]
+              Hiera.debug("Found data in class #{klass}")
+            rescue
+            end
+          else
+            temp_answer = scope[varname]
+          end
+
+          next if temp_answer == :undefined
+
+          if temp_answer
+            # For array resolution we just append to the array whatever we
+            # find, we then go onto the next file and keep adding to the array.
+            #
+            # For priority searches we break after the first found data item.
+            case resolution_type
+            when :array
+              answer ||= []
+              answer << Backend.parse_answer(temp_answer, scope)
+            when :hash
+              answer ||= {}
+              answer = Backend.parse_answer(temp_answer, scope).merge answer
+            else
+              answer = Backend.parse_answer(temp_answer, scope)
+              break
+            end
+          end
+        end
+
+        answer = nil if answer == :undefined
+
+        answer
+      end
     end
+  end
 end
+

--- a/lib/hiera/scope.rb
+++ b/lib/hiera/scope.rb
@@ -1,41 +1,42 @@
 class Hiera
-    class Scope
-        attr_reader :real
+  class Scope
+    attr_reader :real
 
-        def initialize(real)
-            @real = real
-        end
-
-        def [](key)
-            if key == "calling_class"
-                ans = @real.resource.name.to_s.downcase
-            elsif key == "calling_module"
-                ans = @real.resource.name.to_s.downcase.split("::").first
-            else
-                ans = @real.lookupvar(key)
-            end
-
-            # damn you puppet visual basic style variables.
-            return nil if ans == ""
-            return ans
-        end
-
-        def include?(key)
-            return true if ["calling_class", "calling_module"].include?(key)
-
-            return @real.lookupvar(key) != ""
-        end
-
-        def catalog
-            @real.catalog
-        end
-
-        def resource
-            @real.resource
-        end
-
-        def compiler
-            @real.compiler
-        end
+    def initialize(real)
+      @real = real
     end
+
+    def [](key)
+      if key == "calling_class"
+        ans = @real.resource.name.to_s.downcase
+      elsif key == "calling_module"
+        ans = @real.resource.name.to_s.downcase.split("::").first
+      else
+        ans = @real.lookupvar(key)
+      end
+
+      # damn you puppet visual basic style variables.
+      return nil if ans == ""
+      return ans
+    end
+
+    def include?(key)
+      return true if ["calling_class", "calling_module"].include?(key)
+
+      return @real.lookupvar(key) != ""
+    end
+
+    def catalog
+      @real.catalog
+    end
+
+    def resource
+      @real.resource
+    end
+
+    def compiler
+      @real.compiler
+    end
+  end
 end
+

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -21,16 +21,17 @@ module Puppet::Parser::Functions
     default  = args[1]
     override = args[2]
 
-    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-    unless File.exist?(configfile)
-      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
-    end
-
     require 'hiera'
 
-    config = YAML.load_file(configfile)
-    config[:logger] = "puppet"
+    hiera_config = Puppet.settings[:hiera_config]
+    config = {}
+
+    if File.exist?(hiera_config)
+      config = Hiera::Config.load(hiera_config)
+    end
+
+    config[:logger] = 'puppet'
+    config
 
     hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -1,46 +1,48 @@
 module Puppet::Parser::Functions
-    newfunction(:hiera, :type => :rvalue) do |*args|
-        # Functions called from puppet manifests that look like this:
-        #   lookup("foo", "bar")
-        # internally in puppet are invoked:  func(["foo", "bar"])
-        #
-        # where as calling from templates should work like this:
-        #   scope.function_lookup("foo", "bar")
-        #
-        #  Therefore, declare this function with args '*args' to accept any number
-        #  of arguments and deal with puppet's special calling mechanism now:
-        if args[0].is_a?(Array)
-            args = args[0]
-        end
-
-        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
-
-        key = args[0]
-        default = args[1]
-        override = args[2]
-
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-        raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-
-        require 'hiera'
-        require 'hiera/scope'
-
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
-        if self.respond_to?("[]")
-            hiera_scope = self
-        else
-            hiera_scope = Hiera::Scope.new(self)
-        end
-
-        answer = hiera.lookup(key, default, hiera_scope, override, :priority)
-
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
-
-        return answer
+  newfunction(:hiera, :type => :rvalue) do |*args|
+    # Functions called from puppet manifests that look like this:
+    #   lookup("foo", "bar")
+    # internally in puppet are invoked:  func(["foo", "bar"])
+    #
+    # where as calling from templates should work like this:
+    #   scope.function_lookup("foo", "bar")
+    #
+    #  Therefore, declare this function with args '*args' to accept any number
+    #  of arguments and deal with puppet's special calling mechanism now:
+    if args[0].is_a?(Array)
+      args = args[0]
     end
+
+    if args.empty?
+      raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup")
+    end
+
+    key      = args[0]
+    default  = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    unless File.exist?(configfile)
+      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
+    end
+
+    require 'hiera'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    hiera_scope = self
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :priority)
+
+    if answer.nil?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied")
+    end
+
+    return answer
+  end
 end
+

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -1,37 +1,39 @@
 module Puppet::Parser::Functions
-    newfunction(:hiera_array, :type => :rvalue) do |*args|
-        if args[0].is_a?(Array)
-            args = args[0]
-        end
-
-        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
-
-        key = args[0]
-        default = args[1]
-        override = args[2]
-
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-        raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-
-        require 'hiera'
-        require 'hiera/scope'
-
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
-        if self.respond_to?("[]")
-            hiera_scope = self
-        else
-            hiera_scope = Hiera::Scope.new(self)
-        end
-
-        answer = hiera.lookup(key, default, hiera_scope, override, :array)
-
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
-
-        answer
+  newfunction(:hiera_array, :type => :rvalue) do |*args|
+    if args[0].is_a?(Array)
+      args = args[0]
     end
+
+    if args.empty?
+      raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup")
+    end
+
+    key      = args[0]
+    default  = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    unless File.exist?(configfile)
+      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
+    end
+
+    require 'hiera'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    hiera_scope = self
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :array)
+
+    if answer.nil?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied")
+    end
+
+    answer
+  end
 end
+

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -12,16 +12,17 @@ module Puppet::Parser::Functions
     default  = args[1]
     override = args[2]
 
-    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-    unless File.exist?(configfile)
-      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
-    end
-
     require 'hiera'
 
-    config = YAML.load_file(configfile)
-    config[:logger] = "puppet"
+    hiera_config = Puppet.settings[:hiera_config]
+    config = {}
+
+    if File.exist?(hiera_config)
+      config = Hiera::Config.load(hiera_config)
+    end
+
+    config[:logger] = 'puppet'
+    config
 
     hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -12,16 +12,17 @@ module Puppet::Parser::Functions
     default  = args[1]
     override = args[2]
 
-    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-    unless File.exist?(configfile)
-      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
-    end
-
     require 'hiera'
 
-    config = YAML.load_file(configfile)
-    config[:logger] = "puppet"
+    hiera_config = Puppet.settings[:hiera_config]
+    config = {}
+
+    if File.exist?(hiera_config)
+      config = Hiera::Config.load(hiera_config)
+    end
+
+    config[:logger] = 'puppet'
+    config
 
     hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -1,37 +1,39 @@
 module Puppet::Parser::Functions
-    newfunction(:hiera_hash, :type => :rvalue) do |*args|
-        if args[0].is_a?(Array)
-            args = args[0]
-        end
-
-        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
-
-        key = args[0]
-        default = args[1]
-        override = args[2]
-
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-        raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-
-        require 'hiera'
-        require 'hiera/scope'
-
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
-        if self.respond_to?("{}")
-            hiera_scope = self
-        else
-            hiera_scope = Hiera::Scope.new(self)
-        end
-
-        answer = hiera.lookup(key, default, hiera_scope, override, :hash)
-
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
-
-        answer
+  newfunction(:hiera_hash, :type => :rvalue) do |*args|
+    if args[0].is_a?(Array)
+      args = args[0]
     end
+
+    if args.empty?
+      raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup")
+    end
+
+    key      = args[0]
+    default  = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    unless File.exist?(configfile)
+      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
+    end
+
+    require 'hiera'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    hiera_scope = self
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :hash)
+
+    if answer.nil?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied")
+    end
+
+    answer
+  end
 end
+

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -12,16 +12,17 @@ module Puppet::Parser::Functions
     default  = args[1]
     override = args[2]
 
-    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-    unless File.exist?(configfile)
-      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
-    end
-
     require 'hiera'
 
-    config = YAML.load_file(configfile)
-    config[:logger] = "puppet"
+    hiera_config = Puppet.settings[:hiera_config]
+    config = {}
+
+    if File.exist?(hiera_config)
+      config = Hiera::Config.load(hiera_config)
+    end
+
+    config[:logger] = 'puppet'
+    config
 
     hiera = Hiera.new(:config => config)
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -1,38 +1,40 @@
 module Puppet::Parser::Functions
-    newfunction(:hiera_include) do |*args|
-        if args[0].is_a?(Array)
-            args = args[0]
-        end
-
-        raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup") if args.empty?
-
-        key = args[0]
-        default = args[1]
-        override = args[2]
-
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
-
-        raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
-
-        require 'hiera'
-        require 'hiera/scope'
-
-        config = YAML.load_file(configfile)
-        config[:logger] = "puppet"
-
-        hiera = Hiera.new(:config => config)
-
-        if self.respond_to?("[]")
-            hiera_scope = self
-        else
-            hiera_scope = Hiera::Scope.new(self)
-        end
-
-        answer = hiera.lookup(key, default, hiera_scope, override, :array)
-
-        raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
-
-        method = Puppet::Parser::Functions.function(:include)
-        send(method, answer)
+  newfunction(:hiera_include) do |*args|
+    if args[0].is_a?(Array)
+      args = args[0]
     end
+
+    if args.empty?
+      raise(Puppet::ParseError, "Please supply a parameter to perform a Hiera lookup")
+    end
+
+    key      = args[0]
+    default  = args[1]
+    override = args[2]
+
+    configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+
+    unless File.exist?(configfile)
+      raise(Puppet::ParseError, "Hiera config file #{configfile} not readable")
+    end
+
+    require 'hiera'
+
+    config = YAML.load_file(configfile)
+    config[:logger] = "puppet"
+
+    hiera = Hiera.new(:config => config)
+
+    hiera_scope = self
+
+    answer = hiera.lookup(key, default, hiera_scope, override, :array)
+
+    if answer.nil?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied")
+    end
+
+    method = Puppet::Parser::Functions.function(:include)
+    send(method, answer)
+  end
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,6 @@ require 'rspec/mocks'
 require 'mocha'
 
 RSpec.configure do |config|
-    config.mock_with :mocha
+  config.mock_with :mocha
 end
 

--- a/spec/unit/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/parser/functions/hiera_array_spec.rb
@@ -20,3 +20,4 @@ describe 'Puppet::Parser::Functions#hiera_array' do
     expect { @scope.function_hiera_array("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 end
+

--- a/spec/unit/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/parser/functions/hiera_hash_spec.rb
@@ -20,3 +20,4 @@ describe 'Puppet::Parser::Functions#hiera_hash' do
     expect { @scope.function_hiera_hash("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 end
+

--- a/spec/unit/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/parser/functions/hiera_include_spec.rb
@@ -20,3 +20,4 @@ describe 'Puppet::Parser::Functions#hiera_include' do
     expect { @scope.function_hiera_include("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 end
+

--- a/spec/unit/parser/functions/hiera_spec.rb
+++ b/spec/unit/parser/functions/hiera_spec.rb
@@ -20,3 +20,4 @@ describe 'Puppet::Parser::Functions#hiera' do
     expect { @scope.function_hiera("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 end
+

--- a/spec/unit/puppet_backend_spec.rb
+++ b/spec/unit/puppet_backend_spec.rb
@@ -1,149 +1,143 @@
 require 'spec_helper'
 
 class Hiera
-    module Backend
-        describe Puppet_backend do
-            before do
-                Hiera.stubs(:warn)
-                Hiera.stubs(:debug)
-                Backend.stubs(:datasources).yields([])
-                Puppet::Parser::Functions.stubs(:function).with(:include)
+  module Backend
+    describe Puppet_backend do
+      before do
+        Hiera.stubs(:warn)
+        Hiera.stubs(:debug)
+        Backend.stubs(:datasources).yields([])
+        Puppet::Parser::Functions.stubs(:function).with(:include)
 
-                @mockresource = mock
-                @mockresource.stubs(:name).returns("ntp::config")
+        @mockresource = mock
+        @mockresource.stubs(:name).returns("ntp::config")
 
-                @mockscope = mock
-                @mockscope.stubs(:resource).returns(@mockresource)
+        @mockscope = mock
+        @mockscope.stubs(:resource).returns(@mockresource)
 
-                @scope = Scope.new(@mockscope)
+        @scope = Scope.new(@mockscope)
 
-                @backend = Puppet_backend.new
-            end
+        @backend = Puppet_backend.new
+      end
 
-            describe "#hierarchy" do
-                it "should use the configured datasource" do
-                    Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
-                    Config.expects("[]").with(:hierarchy)
+      describe "#hierarchy" do
+        it "should use the configured datasource" do
+          Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
+          Config.expects("[]").with(:hierarchy)
 
-                    ["ntp", "ntp::config"].each do |klass|
-                        Backend.expects(:parse_string).with(klass, @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns(klass)
-                    end
+          ["ntp", "ntp::config"].each do |klass|
+            Backend.expects(:parse_string).with(klass, @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns(klass)
+          end
 
-                    @backend.hierarchy(@scope, nil).should == ["rspec::ntp::config", "rspec::ntp", "ntp::config::rspec", "ntp::rspec"]
-                end
-
-                it "should not include empty class names" do
-                    Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
-                    Config.expects("[]").with(:hierarchy).returns(["%{foo}", "common"])
-
-                    Backend.expects(:parse_string).with("common", @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns("common")
-                    Backend.expects(:parse_string).with("%{foo}", @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns("")
-
-                    @backend.hierarchy(@scope, nil).should == ["rspec::common", "ntp::config::rspec", "ntp::rspec"]
-                end
-
-                it "should allow for an override data source" do
-                    Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
-                    Config.expects("[]").with(:hierarchy)
-
-                    ["ntp", "ntp::config"].each do |klass|
-                        Backend.expects(:parse_string).with(klass, @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns(klass)
-                    end
-
-                    @backend.hierarchy(@scope, "override").should == ["rspec::override", "rspec::ntp::config", "rspec::ntp", "ntp::config::rspec", "ntp::rspec"]
-                end
-
-                describe "#lookup" do
-                    it "should attempt to load data from unincluded classes" do
-                        Backend.expects(:empty_answer).returns(nil)
-                        Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
-
-                        catalog = mock
-                        catalog.expects(:classes).returns([])
-
-                        @scope.expects(:catalog).returns(catalog)
-                        @scope.expects(:function_include).with("rspec")
-                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec")
-
-                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec"])
-                        @backend.lookup("key", @scope, nil, nil).should == "rspec"
-                    end
-
-                    it "should not load loaded classes" do
-                        Backend.expects(:empty_answer).returns(nil)
-                        Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
-                        catalog = mock
-                        catalog.expects(:classes).returns(["rspec"])
-                        @mockscope.expects(:catalog).returns(catalog)
-                        @mockscope.expects(:function_include).never
-                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec")
-
-                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec"])
-                        @backend.lookup("key", @scope, nil, nil).should == "rspec"
-                    end
-
-                    it "should return the first found data" do
-                        Backend.expects(:empty_answer).returns(nil)
-                        Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
-                        catalog = mock
-                        catalog.expects(:classes).returns(["rspec", "override"])
-                        @mockscope.expects(:catalog).returns(catalog)
-                        @mockscope.expects(:function_include).never
-                        @mockscope.expects(:lookupvar).with("override::key").returns("rspec")
-                        @mockscope.expects(:lookupvar).with("rspec::key").never
-
-                        @backend.expects(:hierarchy).with(@scope, "override").returns(["override", "rspec"])
-                        @backend.lookup("key", @scope, "override", nil).should == "rspec"
-                    end
-
-                    it "should return an array of found data for array searches" do
-                        Backend.expects(:empty_answer).returns([])
-                        Backend.expects(:parse_answer).with("rspec::key", @scope).returns("rspec::key")
-                        Backend.expects(:parse_answer).with("test::key", @scope).returns("test::key")
-                        catalog = mock
-                        catalog.expects(:classes).returns(["rspec", "test"])
-                        @mockscope.expects(:catalog).returns(catalog)
-                        @mockscope.expects(:function_include).never
-                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
-                        @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
-
-                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-                        @backend.lookup("key", @scope, nil, :array).should == ["rspec::key", "test::key"]
-                    end
-
-
-                    it "should return a hash of found data for hash searches" do
-                        Backend.expects(:empty_answer).returns({})
-                        Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key'})
-                        Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key'})
-                        catalog = mock
-                        catalog.expects(:classes).returns(["rspec", "test"])
-                        @mockscope.expects(:catalog).returns(catalog)
-                        @mockscope.expects(:function_include).never
-                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
-                        @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
-
-                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-                        @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'test'=>'key'}
-                    end
-
-                    it "should return a merged hash of found data for hash searches" do
-                        Backend.expects(:empty_answer).returns({})
-                        Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key', 'common'=>'rspec'})
-                        Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key', 'common'=>'rspec'})
-                        catalog = mock
-                        catalog.expects(:classes).returns(["rspec", "test"])
-                        @mockscope.expects(:catalog).returns(catalog)
-                        @mockscope.expects(:function_include).never
-                        @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
-                        @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
-
-                        @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
-                        @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'common'=>'rspec', 'test'=>'key'}
-                    end
-                end
-            end
+          @backend.hierarchy(@scope, nil).should == ["rspec::ntp::config", "rspec::ntp", "ntp::config::rspec", "ntp::rspec"]
         end
+
+        it "should not include empty class names" do
+          Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
+          Config.expects("[]").with(:hierarchy).returns(["%{foo}", "common"])
+
+          Backend.expects(:parse_string).with("common", @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns("common")
+          Backend.expects(:parse_string).with("%{foo}", @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns("")
+
+          @backend.hierarchy(@scope, nil).should == ["rspec::common", "ntp::config::rspec", "ntp::rspec"]
+        end
+
+        it "should allow for an override data source" do
+          Config.expects("[]").with(:puppet).returns({:datasource => "rspec"})
+          Config.expects("[]").with(:hierarchy)
+
+          ["ntp", "ntp::config"].each do |klass|
+            Backend.expects(:parse_string).with(klass, @scope, {"calling_module" => "ntp", "calling_class" => "ntp::config"}).returns(klass)
+          end
+
+          @backend.hierarchy(@scope, "override").should == ["rspec::override", "rspec::ntp::config", "rspec::ntp", "ntp::config::rspec", "ntp::rspec"]
+        end
+      end
+
+      describe "#lookup" do
+        it "should attempt to load data from unincluded classes" do
+          Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
+
+          catalog = mock
+          catalog.expects(:classes).returns([])
+
+          @scope.expects(:catalog).returns(catalog)
+          @scope.expects(:function_include).with("rspec")
+          @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec")
+
+          @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec"])
+          @backend.lookup("key", @scope, nil, nil).should == "rspec"
+        end
+
+        it "should not load loaded classes" do
+          Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
+          catalog = mock
+          catalog.expects(:classes).returns(["rspec"])
+          @mockscope.expects(:catalog).returns(catalog)
+          @mockscope.expects(:function_include).never
+          @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec")
+
+          @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec"])
+          @backend.lookup("key", @scope, nil, nil).should == "rspec"
+        end
+
+        it "should return the first found data" do
+          Backend.expects(:parse_answer).with("rspec", @scope).returns("rspec")
+          catalog = mock
+          catalog.expects(:classes).returns(["rspec", "override"])
+          @mockscope.expects(:catalog).returns(catalog)
+          @mockscope.expects(:function_include).never
+          @mockscope.expects(:lookupvar).with("override::key").returns("rspec")
+          @mockscope.expects(:lookupvar).with("rspec::key").never
+
+          @backend.expects(:hierarchy).with(@scope, "override").returns(["override", "rspec"])
+          @backend.lookup("key", @scope, "override", nil).should == "rspec"
+        end
+
+        it "should return an array of found data for array searches" do
+          Backend.expects(:parse_answer).with("rspec::key", @scope).returns("rspec::key")
+          Backend.expects(:parse_answer).with("test::key", @scope).returns("test::key")
+          catalog = mock
+          catalog.expects(:classes).returns(["rspec", "test"])
+          @mockscope.expects(:catalog).returns(catalog)
+          @mockscope.expects(:function_include).never
+          @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
+          @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
+
+          @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
+          @backend.lookup("key", @scope, nil, :array).should == ["rspec::key", "test::key"]
+        end
+
+
+        it "should return a hash of found data for hash searches" do
+          Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key'})
+          Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key'})
+          catalog = mock
+          catalog.expects(:classes).returns(["rspec", "test"])
+          @mockscope.expects(:catalog).returns(catalog)
+          @mockscope.expects(:function_include).never
+          @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
+          @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
+
+          @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
+          @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'test'=>'key'}
+        end
+
+        it "should return a merged hash of found data for hash searches" do
+          Backend.expects(:parse_answer).with("rspec::key", @scope).returns({'rspec'=>'key', 'common'=>'rspec'})
+          Backend.expects(:parse_answer).with("test::key", @scope).returns({'test'=>'key', 'common'=>'rspec'})
+          catalog = mock
+          catalog.expects(:classes).returns(["rspec", "test"])
+          @mockscope.expects(:catalog).returns(catalog)
+          @mockscope.expects(:function_include).never
+          @mockscope.expects(:lookupvar).with("rspec::key").returns("rspec::key")
+          @mockscope.expects(:lookupvar).with("test::key").returns("test::key")
+
+          @backend.expects(:hierarchy).with(@scope, nil).returns(["rspec", "test"])
+          @backend.lookup("key", @scope, nil, :hash).should == {'rspec'=>'key', 'common'=>'rspec', 'test'=>'key'}
+        end
+      end
     end
+  end
 end
 

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,64 +1,64 @@
 require 'spec_helper'
 
 class Hiera
-    describe Scope do
-        describe "#initialize" do
-            it "should store the supplied puppet scope" do
-                real = {}
-                scope = Scope.new(real)
-                scope.real.should == real
-            end
-        end
-
-        describe "#[]" do
-            it "should treat '' as nil" do
-                real = mock
-                real.expects(:lookupvar).with("foo").returns("")
-
-                scope = Scope.new(real)
-                scope["foo"].should == nil
-            end
-
-            it "sould return found data" do
-                real = mock
-                real.expects(:lookupvar).with("foo").returns("bar")
-
-                scope = Scope.new(real)
-                scope["foo"].should == "bar"
-            end
-
-            it "should get calling_class and calling_module from puppet scope" do
-                real = mock
-                resource = mock
-                resource.expects(:name).returns("Foo::Bar").twice
-
-                real.expects(:resource).returns(resource).twice
-
-                scope = Scope.new(real)
-                scope["calling_class"].should == "foo::bar"
-                scope["calling_module"].should == "foo"
-            end
-        end
-
-        describe "#include?" do
-            it "should correctly report missing data" do
-                real = mock
-                real.expects(:lookupvar).with("foo").returns("")
-
-                scope = Scope.new(real)
-                scope.include?("foo").should == false
-            end
-
-            it "should always return true for calling_class and calling_module" do
-                real = mock
-                real.expects(:lookupvar).with("calling_class").never
-                real.expects(:lookupvar).with("calling_module").never
-
-                scope = Scope.new(real)
-                scope.include?("calling_class").should == true
-                scope.include?("calling_module").should == true
-            end
-        end
+  describe Scope do
+    describe "#initialize" do
+      it "should store the supplied puppet scope" do
+        real = {}
+        scope = Scope.new(real)
+        scope.real.should == real
+      end
     end
+
+    describe "#[]" do
+      it "should treat '' as nil" do
+        real = mock
+        real.expects(:lookupvar).with("foo").returns("")
+
+        scope = Scope.new(real)
+        scope["foo"].should == nil
+      end
+
+      it "sould return found data" do
+        real = mock
+        real.expects(:lookupvar).with("foo").returns("bar")
+
+        scope = Scope.new(real)
+        scope["foo"].should == "bar"
+      end
+
+      it "should get calling_class and calling_module from puppet scope" do
+        real = mock
+        resource = mock
+        resource.expects(:name).returns("Foo::Bar").twice
+
+        real.expects(:resource).returns(resource).twice
+
+        scope = Scope.new(real)
+        scope["calling_class"].should == "foo::bar"
+        scope["calling_module"].should == "foo"
+      end
+    end
+
+    describe "#include?" do
+      it "should correctly report missing data" do
+        real = mock
+        real.expects(:lookupvar).with("foo").returns("")
+
+        scope = Scope.new(real)
+        scope.include?("foo").should == false
+      end
+
+      it "should always return true for calling_class and calling_module" do
+        real = mock
+        real.expects(:lookupvar).with("calling_class").never
+        real.expects(:lookupvar).with("calling_module").never
+
+        scope = Scope.new(real)
+        scope.include?("calling_class").should == true
+        scope.include?("calling_module").should == true
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
The hiera-puppet code base now uses two space indentation. This patch
also removes unnecessary calls to `Hiera::Scope`, which is no longer
required because core Puppet's scope object allows variable lookup via
the `[]` method.

This commit includes updated specs.
