### PR TITLE
Make pupet functions obey hiera_config when present in a Puppet configuration.

### DIFF
--- a/lib/puppet/parser/functions/hiera.rb
+++ b/lib/puppet/parser/functions/hiera.rb
@@ -17,7 +17,8 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = Puppet.settings[:hiera_config]
+        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]) if configfile.nil?
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
 

--- a/lib/puppet/parser/functions/hiera_array.rb
+++ b/lib/puppet/parser/functions/hiera_array.rb
@@ -8,7 +8,8 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = Puppet.settings[:hiera_config]
+        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]) if configfile.nil?
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
 

--- a/lib/puppet/parser/functions/hiera_hash.rb
+++ b/lib/puppet/parser/functions/hiera_hash.rb
@@ -10,7 +10,8 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = Puppet.settings[:hiera_config]
+        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]) if configfile.nil?
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
 

--- a/lib/puppet/parser/functions/hiera_include.rb
+++ b/lib/puppet/parser/functions/hiera_include.rb
@@ -8,7 +8,8 @@ module Puppet::Parser::Functions
         default = args[1]
         override = args[2]
 
-        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"])
+        configfile = Puppet.settings[:hiera_config]
+        configfile = File.join([File.dirname(Puppet.settings[:config]), "hiera.yaml"]) if configfile.nil?
 
         raise(Puppet::ParseError, "Hiera config file #{configfile} not readable") unless File.exist?(configfile)
 


### PR DESCRIPTION
Puppet 3.0 supports the configuration of Hiera through the Puppet
configuration file. This allows for hiera_config to be defined
per environment. This forces the Hiera Puppet functions to use
hiera_config first, then use the default as backup. This change
ensures backwards compatibility while allowing the Puppet configuration
control where to look up the Hiera configuration YAML.
