### PR TITLE
(Maint) require PuppetlabsSpec::PuppetSeams#scope_for_test_harness

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,10 @@
-$:.insert(0, File.join([File.dirname(__FILE__), "..", "..", "lib"]))
+$LOAD_PATH.insert(0, File.join([File.dirname(__FILE__), "..", "..", "lib"]))
 
 require 'rubygems'
 require 'rspec'
+require 'rspec/mocks'
+require 'hiera'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'hiera_puppet'
 require 'hiera/backend/puppet_backend'
 require 'hiera/scope'
-require 'rspec/mocks'
-require 'mocha'
-
-module ScopeSpecHelpers
-  def hacked_scope
-    scope = Puppet::Parser::Scope.new
-    def scope.[](key); end
-    scope
-  end
-end
-
-RSpec.configure do |config|
-  config.mock_with :mocha
-  config.include ScopeSpecHelpers
-end
-

--- a/spec/unit/puppet/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_array_spec.rb
@@ -1,30 +1,17 @@
-require 'puppet'
-require 'hiera'
-require 'spec_helper'
-
 describe 'Puppet::Parser::Functions#hiera_array' do
-  before do
-    Puppet::Parser::Functions.function(:hiera_array)
-    @scope = Puppet::Parser::Scope.new
-    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
-    File.stubs(:exist?).with(configfile).returns true
-    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it 'should require a key argument' do
-    expect { @scope.function_hiera_array([]) }.should raise_error(Puppet::ParseError)
+    expect { scope.function_hiera_array([]) }.should raise_error(Puppet::ParseError)
   end
 
   it 'should raise a useful error when nil is returned' do
     Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { @scope.function_hiera_array("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+    expect { scope.function_hiera_array("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 
   it 'should use the array resolution_type' do
-    scope = hacked_scope
-    Hiera.any_instance.expects(:lookup).with('key', nil, scope, nil, :array).returns([])
+    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be :array }.returns([])
     scope.function_hiera_array(['key'])
   end
-
 end
-

--- a/spec/unit/puppet/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_hash_spec.rb
@@ -1,29 +1,17 @@
-require 'puppet'
-require 'hiera'
-require 'spec_helper'
-
 describe 'Puppet::Parser::Functions#hiera_hash' do
-  before do
-    Puppet::Parser::Functions.function(:hiera_hash)
-    @scope = Puppet::Parser::Scope.new
-    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
-    File.stubs(:exist?).with(configfile).returns true
-    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it 'should require a key argument' do
-    expect { @scope.function_hiera_hash([]) }.should raise_error(Puppet::ParseError)
+    expect { scope.function_hiera_hash([]) }.should raise_error(Puppet::ParseError)
   end
 
   it 'should raise a useful error when nil is returned' do
     Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { @scope.function_hiera_hash("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+    expect { scope.function_hiera_hash("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 
   it 'should use the hash resolution_type' do
-    scope = hacked_scope
-    Hiera.any_instance.expects(:lookup).with('key', nil, scope, nil, :hash).returns({})
+    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be :hash }.returns({})
     scope.function_hiera_hash(['key'])
   end
 end
-

--- a/spec/unit/puppet/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_include_spec.rb
@@ -1,30 +1,17 @@
-require 'puppet'
-require 'hiera'
-require 'spec_helper'
-
 describe 'Puppet::Parser::Functions#hiera_include' do
-  before do
-    Puppet::Parser::Functions.function(:hiera_include)
-    @scope = Puppet::Parser::Scope.new
-    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
-    File.stubs(:exist?).with(configfile).returns true
-    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it 'should require a key argument' do
-    expect { @scope.function_hiera_include([]) }.should raise_error(Puppet::ParseError)
+    expect { scope.function_hiera_include([]) }.should raise_error(Puppet::ParseError)
   end
 
   it 'should raise a useful error when nil is returned' do
     Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { @scope.function_hiera_include("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+    expect { scope.function_hiera_include("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 
   it 'should use the array resolution_type' do
-    scope = hacked_scope
-    scope.stubs(:send)
-    Hiera.any_instance.expects(:lookup).with('key', nil, scope, nil, :array).returns([])
+    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be :array }.returns([])
     scope.function_hiera_include(['key'])
   end
 end
-

--- a/spec/unit/puppet/parser/functions/hiera_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_spec.rb
@@ -1,30 +1,21 @@
-require 'puppet'
-require 'hiera'
-require 'hiera/scope'
+#! /usr/bin/env ruby -S rspec
+
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera' do
-  before do
-    Puppet::Parser::Functions.function(:hiera)
-    @scope = Puppet::Parser::Scope.new
-    configfile = File.join(File.dirname(Puppet.settings[:config]), "hiera.yaml")
-    File.stubs(:exist?).with(configfile).returns true
-    YAML.stubs(:load_file).with(configfile).returns(Hash.new)
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it 'should require a key argument' do
-    expect { @scope.function_hiera([]) }.should raise_error(Puppet::ParseError)
+    expect { scope.function_hiera([]) }.should raise_error(Puppet::ParseError)
   end
 
   it 'should raise a useful error when nil is returned' do
     Hiera.any_instance.expects(:lookup).returns(nil)
-    expect { @scope.function_hiera("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
+    expect { scope.function_hiera("badkey") }.should raise_error(Puppet::ParseError, /Could not find data item badkey/ )
   end
 
   it 'should use the priority resolution_type' do
-    scope = hacked_scope
-    Hiera.any_instance.expects(:lookup).with('key', nil, scope, nil, :priority).returns('foo')
-    scope.function_hiera(['key'])
+    Hiera.any_instance.expects(:lookup).with() { |*args| args[4].should be :priority }.returns('foo_result')
+    scope.function_hiera(['key']).should == 'foo_result'
   end
 end
-

--- a/spec/watchr.rb
+++ b/spec/watchr.rb
@@ -1,0 +1,79 @@
+ENV['FOG_MOCK'] ||= 'true'
+ENV['AUTOTEST'] = 'true'
+ENV['WATCHR']   = '1'
+
+system 'clear'
+
+def growl(message)
+  growlnotify = `which growlnotify`.chomp
+  title = "Watchr Test Results"
+  image = case message
+  when /(\d+)\s+?(failure|error)/i
+    ($1.to_i == 0) ? "~/.watchr_images/passed.png" : "~/.watchr_images/failed.png"
+  else
+    '~/.watchr_images/unknown.png'
+  end
+  options = "-w -n Watchr --image '#{File.expand_path(image)}' -m '#{message}' '#{title}'"
+  system %(#{growlnotify} #{options} &)
+end
+
+def run(cmd)
+  puts(cmd)
+  `#{cmd}`
+end
+
+def run_spec_test(file)
+  if File.exist? file
+    result = run "rspec --format p --color #{file}"
+    growl result.split("\n").last
+    puts result
+  else
+    puts "FIXME: No test #{file} [#{Time.now}]"
+  end
+end
+
+def filter_rspec(data)
+  data.split("\n").find_all do |l|
+    l =~ /^(\d+)\s+exampl\w+.*?(\d+).*?failur\w+.*?(\d+).*?pending/
+  end.join("\n")
+end
+
+def run_all_tests
+  system('clear')
+  files = Dir.glob("spec/**/*_spec.rb").join(" ")
+  result = run "rspec #{files}"
+  growl_results = filter_rspec result
+  growl growl_results
+  puts result
+  puts "GROWL: #{growl_results}"
+end
+
+# Ctrl-\
+Signal.trap 'QUIT' do
+  puts " --- Running all tests ---\n\n"
+  run_all_tests
+end
+
+@interrupted = false
+
+# Ctrl-C
+Signal.trap 'INT' do
+  if @interrupted then
+    @wants_to_quit = true
+    abort("\n")
+  else
+    puts "Interrupt a second time to quit"
+    @interrupted = true
+    Kernel.sleep 1.5
+    # raise Interrupt, nil # let the run loop catch it
+    run_suite
+  end
+end
+
+watch( 'spec/.*_spec\.rb' ) do |md|
+  run_all_tests
+end
+
+watch( 'lib/.*\.rb' ) do |md|
+  run_all_tests
+end


### PR DESCRIPTION
Without this patch the Hiera spec tests fail against Puppet 3.x and later.
The specs fail because the method signature of the Puppet::Parser::Scope
class initializer has changed from Puppet 2.7 behavior.

This patch fixes the problem by switching over all uses of
Puppet::Parser::Scope.new to the seam method implemented in the common
spec helper in PuppetlabsSpec::PuppetSeams#scope_for_test_harness
