### PR TITLE
(Maint) Rename PuppetlabsSpec::Puppet{Seams,Internals}

### DIFF
--- a/spec/unit/hiera_puppet_spec.rb
+++ b/spec/unit/hiera_puppet_spec.rb
@@ -69,7 +69,7 @@ describe 'HieraPuppet' do
   end
 
   describe 'HieraPuppet#lookup' do
-    let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+    let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
     it "should return the value from Hiera" do
       Hiera.any_instance.stubs(:lookup).returns('8080')

--- a/spec/unit/puppet/parser/functions/hiera_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_array_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera_array' do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should require a key argument' do
     expect { scope.function_hiera_array([]) }.to raise_error(Puppet::ParseError)

--- a/spec/unit/puppet/parser/functions/hiera_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_hash_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera_hash' do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should require a key argument' do
     expect { scope.function_hiera_hash([]) }.to raise_error(Puppet::ParseError)

--- a/spec/unit/puppet/parser/functions/hiera_include_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_include_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera_include' do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should require a key argument' do
     expect { scope.function_hiera_include([]) }.to raise_error(Puppet::ParseError)

--- a/spec/unit/puppet/parser/functions/hiera_spec.rb
+++ b/spec/unit/puppet/parser/functions/hiera_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'Puppet::Parser::Functions#hiera' do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should require a key argument' do
     expect { scope.function_hiera([]) }.to raise_error(Puppet::ParseError)


### PR DESCRIPTION
The module PuppetlabsSpec::PuppetSeams has been renamed in the 
puppetlabs_spec_helper gem to PuppetlabsSpec::PuppetInternals.

The method to obtain a scope object has also changed slightly.  Without this
patch the spec tests will fail because the stdlib module is not aligned with
the spec helper gem.  This patch fixes the problem by matching up messages
with their receivers in the spec helper library.

This change was made with:

   find \* -type f -print0 | xargs -0 perl -pl -i -e 's/seams/Internals/gi'
   find \* -type f -print0 | xargs -0 perl -pl -i -e 's/parser_scope/scope/gi'

Paired-with: Andrew Parker andy@puppetlabs.com
