### PR TITLE
(#15291) Add Vendor tag to Hiera-Puppet spec file

### DIFF
--- a/ext/redhat/hiera-puppet.spec.erb
+++ b/ext/redhat/hiera-puppet.spec.erb
@@ -10,7 +10,7 @@ Name:           hiera-puppet
 Version:        %{rpmversion}
 Release:        <%= @release -%>%{?dist}
 Summary:        A data backend for Hiera that can query the internal Puppet scope for data.
-
+Vendor:         %{?_host_vendor}
 Group:          System Environment/Base
 License:        Apache 2.0
 URL:            http://projects.puppetlabs.com/projects/%{name}/


### PR DESCRIPTION
Previously the spec file had no Vendor tag, which left it undefined. This
commit adds a Vendor tag that references the _host_vendor macro, so that it can
be easily set to 'Puppet Labs' internally and customized by users easily. The
Vendor tag makes it easier for users to tell where the package came from.
