### PR TITLE
Add hiera_puppet.rb to debian, redhat packages, fix gem version dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ spec = Gem::Specification.new do |s|
   s.require_path = "lib"
   s.test_files = FileList["spec/**/*.rb"].to_a
   s.has_rdoc = true
-  s.add_dependency 'hiera', '~>1.0'
+  s.add_dependency 'hiera', '>=1.0.0rc'
   s.executables = "extlookup2hiera"
 end
 

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -23,6 +23,7 @@ install/hiera-puppet::
 	mkdir -p  $(BIN_DIR)
 	mkdir -p  $(DOC_DIR)
 	cp -pr    lib/hiera $(RUBYLIB)
+	cp -p     lib/hiera_puppet.rb $(RUBYLIB)
 	cp -pr    lib/puppet $(RUBYLIB)
 	cp -p     bin/extlookup2hiera $(BIN_DIR)
 	cp -p     CHANGELOG COPYING README.md $(DOC_DIR)

--- a/ext/redhat/hiera-puppet.spec.erb
+++ b/ext/redhat/hiera-puppet.spec.erb
@@ -38,6 +38,7 @@ rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{ruby_sitelibdir}
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 cp -pr lib/hiera $RPM_BUILD_ROOT/%{ruby_sitelibdir}
+cp -p lib/hiera_puppet.rb $RPM_BUILD_ROOT/%{ruby_sitelibdir}
 cp -pr lib/puppet $RPM_BUILD_ROOT/%{ruby_sitelibdir}
 install -p -m0755 bin/extlookup2hiera $RPM_BUILD_ROOT/%{_bindir}
 
@@ -49,6 +50,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{_bindir}/extlookup2hiera
 %{ruby_sitelibdir}/hiera/scope.rb
+%{ruby_sitelibdir}/hiera_puppet.rb
 %{ruby_sitelibdir}/hiera/backend/puppet_backend.rb
 %{ruby_sitelibdir}/puppet/parser/functions/hiera.rb
 %{ruby_sitelibdir}/puppet/parser/functions/hiera_array.rb

--- a/tasks/apple.rake
+++ b/tasks/apple.rake
@@ -125,6 +125,7 @@ def pack_source
   # Make all necessary directories
   directories = ["#{work}/usr/bin",
                  "#{work}/usr/share/doc/#{@package_name}",
+                 "#{work}/usr/lib/ruby/site_ruby/1.8",
                  "#{work}/usr/lib/ruby/site_ruby/1.8/hiera",
                  "#{work}/usr/lib/ruby/site_ruby/1.8/puppet"]
   FileUtils.mkdir_p(directories)


### PR DESCRIPTION
Previously lib/hiera_puppet.rb was not installed on redhat or debian packages.
This commit addresses that by adding the file to the spec/rules file
accordingly. It also updates the gem version requriement for the hiera
dependency to >= 1.0.0rc, as 1.0.0rc2 is not ~> 1.0.
