### PR TITLE
Fix lint warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem 'puppet'
+gem 'puppet-lint'
+gem 'puppetlabs_spec_helper'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    facter (1.6.11)
+    metaclass (0.0.1)
+    mocha (0.12.3)
+      metaclass (~> 0.0.1)
+    puppet (2.7.19)
+      facter (~> 1.5)
+    puppet-lint (0.2.1)
+    puppetlabs_spec_helper (0.3.0)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rake (0.9.2.2)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.2)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.11.2)
+    rspec-puppet (0.1.4)
+      rspec
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet
+  puppet-lint
+  puppetlabs_spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
+require 'puppet-lint/tasks/puppet-lint'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 

--- a/example/modules/data/manifests/common.pp
+++ b/example/modules/data/manifests/common.pp
@@ -1,3 +1,4 @@
+# sets the common (across all puppet conf) ntp servers.
 class data::common {
-  $ntpservers = ["ntp1.example.com", "ntp2.example.com"]
+  $ntpservers = ['ntp1.example.com', 'ntp2.example.com']
 }

--- a/example/modules/ntp/manifests/config.pp
+++ b/example/modules/ntp/manifests/config.pp
@@ -1,5 +1,6 @@
-class ntp::config($ntpservers = hiera("ntpservers")) {
-  file{"/tmp/ntp.conf":
-    content => template("ntp/ntp.conf.erb")
+# lookup ntpservers from hiera, or allow user of class to provide other value
+class ntp::config($ntpservers = hiera('ntpservers')) {
+  file{'/tmp/ntp.conf':
+    content => template('ntp/ntp.conf.erb')
   }
 }

--- a/example/modules/ntp/manifests/data.pp
+++ b/example/modules/ntp/manifests/data.pp
@@ -1,3 +1,4 @@
+# this class will be loaded using hiera's 'puppet' backend
 class ntp::data {
-  $ntpservers = ["1.pool.ntp.org", "2.pool.ntp.org"]
+  $ntpservers = ['1.pool.ntp.org', '2.pool.ntp.org']
 }

--- a/example/modules/users/manifests/common.pp
+++ b/example/modules/users/manifests/common.pp
@@ -1,3 +1,4 @@
+# notifies
 class users::common {
-  notify{"Adding users::common": }
+  notify{'Adding users::common': }
 }

--- a/example/modules/users/manifests/dc1.pp
+++ b/example/modules/users/manifests/dc1.pp
@@ -1,3 +1,4 @@
+# notifies
 class users::dc1 {
-  notify{"Adding users::dc1": }
+  notify{'Adding users::dc1': }
 }

--- a/example/modules/users/manifests/development.pp
+++ b/example/modules/users/manifests/development.pp
@@ -1,3 +1,4 @@
+# notifies
 class users::development {
-  notify{"Adding users::development": }
+  notify{'Adding users::development': }
 }

--- a/example/site.pp
+++ b/example/site.pp
@@ -1,3 +1,3 @@
 node default {
-  hiera_include("classes")
+  hiera_include('classes')
 }


### PR DESCRIPTION
By default (using puppetlabs' recommended rake helper for rspecs) the lint task checks all subfolders, including this one, if I'm using it.

So I fixed the warnings.
