### PR TITLE
Handle when the configuration variable is false

### DIFF
--- a/lib/hiera/backend/puppet_backend.rb
+++ b/lib/hiera/backend/puppet_backend.rb
@@ -71,9 +71,10 @@ class Hiera
             temp_answer = scope[varname]
           end
 
-          next if temp_answer == :undefined
-
-          if temp_answer
+          # Note that temp_answer might be define but false.
+          if temp_answer.nil?
+            next
+          else
             # For array resolution we just append to the array whatever we
             # find, we then go onto the next file and keep adding to the array.
             #


### PR DESCRIPTION
Consider:

class foomodule::params {

  $myitem = false

...

The current code won't handle this because

if temp_answer == if false

Use temp_anser.nil?
